### PR TITLE
Plan Rendering

### DIFF
--- a/Sample.Forms.UWP/Sample.Forms.UWP.csproj
+++ b/Sample.Forms.UWP/Sample.Forms.UWP.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>Sample.Forms.UWP</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.17763.0</TargetPlatformVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.18362.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>

--- a/Svg.Editor.Core/Extensions/SvgVisualElementExtensions.cs
+++ b/Svg.Editor.Core/Extensions/SvgVisualElementExtensions.cs
@@ -83,50 +83,5 @@ namespace Svg.Editor.Extensions
             }
             e.CustomAttributes[ToolBase.ConstraintsCustomAttributeKey] = constraints;
         }
-
-        public static SizeF GetImageSize(this SvgImage image)
-        {
-            // handle data/uri embedded images (http://en.wikipedia.org/wiki/Data_URI_scheme)
-            if (image.Href.IsAbsoluteUri && image.Href.Scheme == "data")
-            {
-                string uriString = image.Href.OriginalString;
-                int dataIdx = uriString.IndexOf(",") + 1;
-                if (dataIdx <= 0 || dataIdx + 1 > uriString.Length)
-                    throw new Exception("Invalid data URI");
-
-                // we're assuming base64, as ascii encoding would be *highly* unsusual for images
-                // also assuming it's png or jpeg mimetype
-                byte[] imageBytes = Convert.FromBase64String(uriString.Substring(dataIdx));
-                using (var stream = new MemoryStream(imageBytes))
-                {
-                    var img = SvgEngine.Factory.CreateImageFromStream(stream);
-                    return SizeF.Create(img.Width, img.Height);
-                }
-            }
-
-            if (!image.Href.IsAbsoluteUri && image.OwnerDocument.BaseUri != null)
-            {
-                image.Href = new Uri(image.OwnerDocument.BaseUri, image.Href);
-            }
-
-            //// should work with http: and file: protocol urls
-            //var httpRequest = WebRequest.Create(uri);
-            //using (WebResponse webResponse = httpRequest.GetResponse())
-            using (var stream = SvgEngine.Resolve<IWebRequest>().GetResponse(image.Href))
-            {
-                stream.Position = 0;
-                if (image.Href.LocalPath.ToLowerInvariant().EndsWith(".svg"))
-                {
-                    var doc = SvgDocument.Open<SvgDocument>(stream);
-                    doc.BaseUri = image.Href;
-                    return doc.GetDimensions();
-                }
-                else
-                {
-                    var img = SvgEngine.Factory.CreateBitmapFromStream(stream);
-                    return SizeF.Create(img.Width, img.Height);
-                }
-            }
-        }
     }
 }

--- a/Svg.Editor.Core/Svg.Editor.Core.csproj
+++ b/Svg.Editor.Core/Svg.Editor.Core.csproj
@@ -58,7 +58,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="SkiaSharp" Version="1.68.1" />
-    <PackageReference Include="Svg" Version="2.4.0.2" />
+    <PackageReference Include="Svg" Version="2.4.3.1" />
     <PackageReference Include="System.Reactive" Version="4.0.0" />
   </ItemGroup>
 </Project>

--- a/Svg.Editor.Core/SvgDrawingCanvas.cs
+++ b/Svg.Editor.Core/SvgDrawingCanvas.cs
@@ -686,7 +686,7 @@ namespace Svg.Editor
 			try
 			{
 				var documentSize = Document.CalculateDocumentBounds();
-				SetDocumentViewbox(documentSize);
+				Document.SetDocumentViewbox(documentSize);
 				Document.Write(stream);
 
 				FireToolCommandsChanged();
@@ -716,7 +716,7 @@ namespace Svg.Editor
 
 			try
 			{
-				SetDocumentViewbox(drawingClip);
+                Document.SetDocumentViewbox(drawingClip);
 				Document.Write(stream);
 
 				FireToolCommandsChanged();
@@ -732,36 +732,9 @@ namespace Svg.Editor
 		}
 
 		public Bitmap CaptureDocumentBitmap(int maxSize = 4096, Color backgroundColor = null)
-		{
-			var documentBounds = Document.CalculateDocumentBounds();
-
-			// determine width and height of the bitmap by the minimum of the whole document's and the constraint's size
-			var drawingWidth = (int) Math.Round(Math.Min(documentBounds.Width, Constraints?.Width ?? float.MaxValue));
-			var drawingHeight =
-				(int) Math.Round(Math.Min(documentBounds.Height, Constraints?.Height ?? float.MaxValue));
-
-			// adjust width and height of the resulting bitmap to the maxSize parameter
-			var bitmapWidth = drawingWidth;
-			var bitmapHeight = drawingHeight;
-
-			if (bitmapWidth > maxSize)
-			{
-				var factor = bitmapWidth / maxSize;
-				bitmapWidth /= factor;
-				bitmapHeight /= factor;
-			}
-
-			if (bitmapHeight > maxSize)
-			{
-				var factor = bitmapHeight / maxSize;
-				bitmapWidth /= factor;
-				bitmapHeight /= factor;
-			}
-
-			var bitmap = Bitmap.Create(bitmapWidth, bitmapHeight);
-
-			return RenderBitmap(bitmap, backgroundColor, documentBounds);
-		}
+        {
+            return Document.CaptureDocumentBitmap(Constraints, maxSize, backgroundColor);
+        }
 
 		public Bitmap CaptureScreenBitmap(Color backgroundColor = null)
 		{
@@ -774,46 +747,9 @@ namespace Svg.Editor
 			var drawingClip = RectangleF.Create(ScreenToCanvas(0, 0), SizeF.Create(drawingWidth, drawingHeight));
 			var bitmap = Bitmap.Create(drawingWidth, drawingHeight);
 
-			return RenderBitmap(bitmap, backgroundColor, drawingClip);
+			return Document.RenderBitmap(bitmap, backgroundColor, drawingClip);
 		}
-
-		private Bitmap RenderBitmap(Bitmap bitmap, Color backgroundColor, RectangleF drawingClip)
-		{
-			if (drawingClip == null || drawingClip == RectangleF.Empty) return bitmap;
-
-			// stash the old values
-			var oldWidth = Document.Width;
-			var oldHeight = Document.Height;
-			var oldViewBox = Document.ViewBox;
-
-			try
-			{
-				SetDocumentViewbox(drawingClip);
-				Document.Draw(bitmap, backgroundColor ?? SvgEngine.Factory.Colors.Black);
-
-				return bitmap;
-			}
-			finally
-			{
-				// reset to old values
-				Document.ViewBox = oldViewBox;
-				Document.Width = oldWidth;
-				Document.Height = oldHeight;
-			}
-		}
-
-		private void SetDocumentViewbox(RectangleF drawingSize)
-		{
-			var x = Math.Max(drawingSize.X, Constraints?.X ?? float.MinValue);
-			var y = Math.Max(drawingSize.Y, Constraints?.Y ?? float.MinValue);
-			var width = Math.Min(drawingSize.Width, Constraints?.Width ?? float.MaxValue);
-			var height = Math.Min(drawingSize.Height, Constraints?.Height ?? float.MaxValue);
-			Document.Width = new SvgUnit(SvgUnitType.Pixel, width);
-			Document.Height = new SvgUnit(SvgUnitType.Pixel, height);
-			Document.ViewBox = new SvgViewBox(x, y, width, height);
-			Document.AspectRatio = new SvgAspectRatio(SvgPreserveAspectRatio.xMidYMid, true);
-		}
-
+		
 		public void FireInvalidateCanvas()
 		{
 			_schedulerProvider.MainScheduer.Schedule(this, (s, st) =>

--- a/Svg.Editor.Core/Tools/PlaceAsBackgroundTool.cs
+++ b/Svg.Editor.Core/Tools/PlaceAsBackgroundTool.cs
@@ -64,17 +64,6 @@ namespace Svg.Editor.Tools
             {
                 var children = Canvas.Document.Children;
 
-                // create image from path
-                if (!path.StartsWith("/")) path = path.Insert(0, "/");
-                var image = new SvgImage
-                {
-                    Href = new Uri($"file://{path}", UriKind.Absolute)
-                };
-
-                // add custom icl attributes
-                image.CustomAttributes.Add(BackgroundCustomAttributeKey, "");
-                image.AddConstraints(NoSnappingConstraint, NoFillConstraint, NoStrokeConstraint);
-
                 // remove already placed background
                 var formerBackground = children.FirstOrDefault(x => x.CustomAttributes.ContainsKey(BackgroundCustomAttributeKey));
                 if (formerBackground != null)
@@ -83,19 +72,15 @@ namespace Svg.Editor.Tools
                     formerBackground.Dispose();
                 }
 
+                var image = Canvas.Document.AddImageInBackground(path);
+                // add custom icl attributes
+                image.CustomAttributes.Add(BackgroundCustomAttributeKey, "");
+                image.AddConstraints(NoSnappingConstraint, NoFillConstraint, NoStrokeConstraint);
                 // add constraints to the canvas
                 var size = image.GetImageSize();
 
                 Canvas.Constraints = RectangleF.Create(0, 0, size.Width, size.Height);
-
-                // insert the background before the first visible element
-                var index = children.IndexOf(children.FirstOrDefault(x => x is SvgVisualElement));
-
-                // if there are no visual elements, we want to add it to the end of the list
-                if (index == -1) index = children.Count;
-
-                children.Insert(index, image);
-
+                
                 Canvas.FireInvalidateCanvas();
                 Canvas.FireToolCommandsChanged();
             }

--- a/Svg.Editor.Core/Tools/SelectionTool.cs
+++ b/Svg.Editor.Core/Tools/SelectionTool.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Svg.Editor.Extensions;
 using Svg.Editor.Gestures;
 using Svg.Editor.Interfaces;
 using Svg.Editor.UndoRedo;
@@ -206,6 +207,7 @@ namespace Svg.Editor.Tools
             foreach (var element in selected)
             {
                 if (element.CustomAttributes.ContainsKey(BackgroundCustomAttributeKey)) continue;
+                if (element.CustomAttributes.ContainsKey(HittestInvisibleAttributeKey)) continue;
                 ws.SelectedElements.Add(element);
             }
         }

--- a/Svg.Editor.Core/Tools/ToolBase.cs
+++ b/Svg.Editor.Core/Tools/ToolBase.cs
@@ -44,6 +44,10 @@ namespace Svg.Editor.Tools
         /// </summary>
         public const string ImmutableTextConstraint = "text";
         /// <summary>
+        /// Add this to disable this element from ever being selected.
+        /// </summary>
+        public const string HittestInvisibleAttributeKey = "data-iclhittestinvisible";
+        /// <summary>
         /// This attribute is place on an element to determine the constraints for editing tools.
         /// Possible values would be:
         /// <list type="bullet">

--- a/Svg.Editor.Forms/Svg.Editor.Forms.csproj
+++ b/Svg.Editor.Forms/Svg.Editor.Forms.csproj
@@ -3,7 +3,7 @@
     <RootNamespace>Svg.Editor.Forms</RootNamespace>
     <AssemblyName>Svg.Editor.Forms</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
-    <TargetFrameworks>netstandard2.0;MonoAndroid81;Xamarin.iOS10;uap10.0.16299</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;MonoAndroid81;Xamarin.iOS10;uap10.0.17763</TargetFrameworks>
     <Version>2.4.1</Version>
     <PackageReleaseNotes>
     </PackageReleaseNotes>
@@ -44,7 +44,7 @@
   
   <ItemGroup>
     <PackageReference Include="SkiaSharp.Views.Forms" Version="1.68.1" />
-    <PackageReference Include="Svg" Version="2.4.0.2" />
+    <PackageReference Include="Svg" Version="2.4.3.1" />
     <PackageReference Include="System.Reactive" Version="4.0.0" />
     <PackageReference Include="Xamarin.Forms" Version="4.1.0.778454" />
   </ItemGroup>

--- a/Svg.Editor.Sample.Forms/Svg.Editor.Sample.Forms.iOS/project.json
+++ b/Svg.Editor.Sample.Forms/Svg.Editor.Sample.Forms.iOS/project.json
@@ -3,7 +3,7 @@
     "Acr.UserDialogs": "6.3.9",
     "SkiaSharp": "1.68.1",
     "SkiaSharp.Views.Forms": "1.68.1",
-    "Svg": "2.4.0.2",
+    "Svg": "2.4.3.1",
     "System.Reactive": "3.1.1",
     "System.Reactive.Core": "3.1.1",
     "System.Reactive.Interfaces": "3.1.1",

--- a/Svg.Editor.Sample.Forms/Svg.Editor.Sample.Forms/Svg.Editor.Sample.Forms.csproj
+++ b/Svg.Editor.Sample.Forms/Svg.Editor.Sample.Forms/Svg.Editor.Sample.Forms.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Acr.UserDialogs" Version="6.3.9" />
     <PackageReference Include="SkiaSharp.Views.Forms" Version="1.68.1" />
-    <PackageReference Include="Svg" Version="2.4.0.2" />
+    <PackageReference Include="Svg" Version="2.4.3.1" />
     <PackageReference Include="System.Reactive" Version="4.0.0" />
     <PackageReference Include="Xam.Plugin.Media" Version="4.0.1.5" />
     <PackageReference Include="Xamarin.Forms" Version="4.1.0.778454" />

--- a/Svg.Editor.Views/Svg.Editor.Views.csproj
+++ b/Svg.Editor.Views/Svg.Editor.Views.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/2.0.46">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;MonoAndroid81;Xamarin.iOS10;uap10.0.16299</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;MonoAndroid81;Xamarin.iOS10;uap10.0.17763</TargetFrameworks>
     <Version>2.4.1</Version>
     <PackageReleaseNotes>
     </PackageReleaseNotes>

--- a/Svg/Platform/Shared/SvgTextReader.cs
+++ b/Svg/Platform/Shared/SvgTextReader.cs
@@ -25,6 +25,8 @@ namespace Svg
                 DtdProcessing = DtdProcessing.Ignore,
                 //WhitespaceHandling = WhitespaceHandling.Significant,
             };
+            if (stream.Length == stream.Position)
+                throw new InvalidOperationException("The provided streams position is at EOF! Cannot load svg document");
             _xml = XmlReader.Create(stream, settings);
             _entities = entities;
         }

--- a/Svg/Svg.csproj
+++ b/Svg/Svg.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/2.0.54">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;MonoAndroid81;Xamarin.iOS10;uap10.0.16299;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;MonoAndroid81;Xamarin.iOS10;uap10.0.18362;net462</TargetFrameworks>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-    <Version>2.4.0.2</Version>
+    <Version>2.4.3.1</Version>
     <Authors>gentledpp,bruzkovsky</Authors>
     <Company>Opti-Q GmbH</Company>
     <PackageReleaseNotes>netstandard multiplatform</PackageReleaseNotes>

--- a/Svg/SvgDocument.cs
+++ b/Svg/SvgDocument.cs
@@ -657,7 +657,17 @@ namespace Svg
                     documentSize = documentSize.UnionAndCopy(bounds);
             }
 
-            return documentSize ?? RectangleF.Create();
+            documentSize ??= RectangleF.Create();
+
+            if (!Transforms.Any())
+                return documentSize;
+            
+            var m = Matrix.Create();
+            foreach(var transform in Transforms)
+                transform.ApplyTo(m);
+
+            return m.TransformRectangle(documentSize);
+
         }
 
         public override void Write(IXmlTextWriter writer)

--- a/Svg/SvgDocumentExtensions.cs
+++ b/Svg/SvgDocumentExtensions.cs
@@ -1,0 +1,144 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using Svg.Interfaces;
+
+namespace Svg;
+
+public static class SvgDocumentExtensions
+{
+    public static SvgImage AddImageInBackground(this SvgDocument doc, string path)
+    {
+        try
+        {
+            var children = doc.Children;
+
+            // create image from path
+            if (!path.StartsWith("/")) path = path.Insert(0, "/");
+            var image = new SvgImage
+            {
+                Href = new Uri($"file://{path}", UriKind.Absolute)
+            };
+            var size = image.GetImageSize();
+            image.X = new SvgUnit(0);
+            image.Y = new SvgUnit(0);
+            image.Width = new SvgUnit(size.Width);
+            image.Height = new SvgUnit(size.Height);
+                
+            // insert the background before the first visible element
+            var index = children.IndexOf(children.FirstOrDefault(x => x is SvgVisualElement));
+
+            // if there are no visual elements, we want to add it to the end of the list
+            if (index == -1) index = children.Count;
+
+            children.Insert(index, image);
+
+            return image;
+        }
+        catch (IOException)
+        {
+            throw;
+        }
+    }
+    public static SvgImage AddImage(this SvgDocument doc, string path)
+    {
+        try
+        {
+            var children = doc.Children;
+
+            // create image from path
+            if (!path.StartsWith("/")) path = path.Insert(0, "/");
+            var image = new SvgImage
+            {
+                Href = new Uri($"file://{path}", UriKind.Absolute)
+            };
+            var size = image.GetImageSize();
+            image.X = new SvgUnit(0);
+            image.Y = new SvgUnit(0);
+            image.Width = new SvgUnit(size.Width);
+            image.Height = new SvgUnit(size.Height);
+
+            children.Add(image);
+
+            return image;
+        }
+        catch (IOException)
+        {
+            throw;
+        }
+    }
+
+
+    public static Bitmap CaptureDocumentBitmap(this SvgDocument document, 
+        RectangleF constraints = null,
+        int maxSize = 4096, 
+        Color backgroundColor = null)
+    {
+        var documentBounds = document.CalculateDocumentBounds();
+
+        // determine width and height of the bitmap by the minimum of the whole document's and the constraint's size
+        var drawingWidth = (int)Math.Round(Math.Min(documentBounds.Width, constraints?.Width ?? float.MaxValue));
+        var drawingHeight =
+            (int)Math.Round(Math.Min(documentBounds.Height, constraints?.Height ?? float.MaxValue));
+
+        // adjust width and height of the resulting bitmap to the maxSize parameter
+        var bitmapWidth = drawingWidth;
+        var bitmapHeight = drawingHeight;
+
+        if (bitmapWidth > maxSize)
+        {
+            var factor = bitmapWidth / maxSize;
+            bitmapWidth /= factor;
+            bitmapHeight /= factor;
+        }
+
+        if (bitmapHeight > maxSize)
+        {
+            var factor = bitmapHeight / maxSize;
+            bitmapWidth /= factor;
+            bitmapHeight /= factor;
+        }
+
+        var bitmap = Bitmap.Create(bitmapWidth, bitmapHeight);
+
+        return document.RenderBitmap(bitmap, backgroundColor, documentBounds);
+    }
+
+    public static Bitmap RenderBitmap(this SvgDocument document, Bitmap bitmap, Color backgroundColor, RectangleF drawingClip)
+    {
+        if (drawingClip == null || drawingClip == RectangleF.Empty) return bitmap;
+
+        // stash the old values
+        var oldWidth = document.Width;
+        var oldHeight = document.Height;
+        var oldViewBox = document.ViewBox;
+
+        try
+        {
+            document.SetDocumentViewbox(drawingClip);
+            document.Draw(bitmap, backgroundColor ?? SvgEngine.Factory.Colors.Black);
+
+            return bitmap;
+        }
+        finally
+        {
+            // reset to old values
+            document.ViewBox = oldViewBox;
+            document.Width = oldWidth;
+            document.Height = oldHeight;
+        }
+    }
+
+    public static void SetDocumentViewbox(this SvgDocument document, RectangleF drawingSize, RectangleF constraints = null)
+    {
+        var x = Math.Max(drawingSize.X, constraints?.X ?? float.MinValue);
+        var y = Math.Max(drawingSize.Y, constraints?.Y ?? float.MinValue);
+        var width = Math.Min(drawingSize.Width, constraints?.Width ?? float.MaxValue);
+        var height = Math.Min(drawingSize.Height, constraints?.Height ?? float.MaxValue);
+        document.Width = new SvgUnit(SvgUnitType.Pixel, width);
+        document.Height = new SvgUnit(SvgUnitType.Pixel, height);
+        document.ViewBox = new SvgViewBox(x, y, width, height);
+        document.AspectRatio = new SvgAspectRatio(SvgPreserveAspectRatio.xMidYMid, true);
+    }
+
+}

--- a/Svg/SvgExtentions.cs
+++ b/Svg/SvgExtentions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
 using System.IO;
@@ -125,6 +124,21 @@ namespace Svg
                 PointF.Create(rectangle.Right, rectangle.Bottom),
                 PointF.Create(rectangle.Left, rectangle.Bottom)
             };
+        }
+        
+        /// <summary>
+        /// Recursively get all descendant elements in DFS order
+        /// </summary>
+        /// <param name="element"></param>
+        /// <returns></returns>
+        public static IEnumerable<SvgElement> GetDescendants(this SvgElement element)
+        {
+            foreach (var child in element.Children)
+            {
+                yield return child;
+                foreach (var grandChild in child.GetDescendants())
+                    yield return grandChild;
+            }
         }
     }
 }

--- a/Svg/SvgImageExtensions.cs
+++ b/Svg/SvgImageExtensions.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.IO;
+using Svg.Interfaces;
+
+namespace Svg;
+
+public static class SvgImageExtensions
+{
+
+    public static SizeF GetImageSize(this SvgImage image)
+    {
+        // handle data/uri embedded images (http://en.wikipedia.org/wiki/Data_URI_scheme)
+        if (image.Href.IsAbsoluteUri && image.Href.Scheme == "data")
+        {
+            string uriString = image.Href.OriginalString;
+            int dataIdx = uriString.IndexOf(",") + 1;
+            if (dataIdx <= 0 || dataIdx + 1 > uriString.Length)
+                throw new Exception("Invalid data URI");
+
+            // we're assuming base64, as ascii encoding would be *highly* unsusual for images
+            // also assuming it's png or jpeg mimetype
+            byte[] imageBytes = Convert.FromBase64String(uriString.Substring(dataIdx));
+            using (var stream = new MemoryStream(imageBytes))
+            {
+                var img = SvgEngine.Factory.CreateImageFromStream(stream);
+                return SizeF.Create(img.Width, img.Height);
+            }
+        }
+
+        if (!image.Href.IsAbsoluteUri && image.OwnerDocument.BaseUri != null)
+        {
+            image.Href = new Uri(image.OwnerDocument.BaseUri, image.Href);
+        }
+
+        //// should work with http: and file: protocol urls
+        //var httpRequest = WebRequest.Create(uri);
+        //using (WebResponse webResponse = httpRequest.GetResponse())
+        using (var stream = SvgEngine.Resolve<IWebRequest>().GetResponse(image.Href))
+        {
+            stream.Position = 0;
+            if (image.Href.LocalPath.ToLowerInvariant().EndsWith(".svg"))
+            {
+                var doc = SvgDocument.Open<SvgDocument>(stream);
+                doc.BaseUri = image.Href;
+                return doc.GetDimensions();
+            }
+            else
+            {
+                var img = SvgEngine.Factory.CreateBitmapFromStream(stream);
+                return SizeF.Create(img.Width, img.Height);
+            }
+        }
+    }
+}

--- a/Tests/SvgW3CTestRunner.Droid/Resources/Resource.Designer.cs
+++ b/Tests/SvgW3CTestRunner.Droid/Resources/Resource.Designer.cs
@@ -14,7 +14,7 @@ namespace SvgW3CTestRunner.Droid
 {
 	
 	
-	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "1.0.0.0")]
+	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "13.0.0.73")]
 	public partial class Resource
 	{
 		


### PR DESCRIPTION
- refactored svg library for planrendering
- defaulted back to uap10.0.17763
- added "getdescendants" helper funciton, fixed custom attribute not starting with "data-"
- fix: Transformations of an SvgDocument affect the calculated documentbounds
- fix: added a better exception message given a svg document should be read from a stream which is already at EOF