### PR TITLE
#9858 - add tool to draw polygons in svg editor

### DIFF
--- a/Svg.Editor.Core.Tests/SelectionToolTests.cs
+++ b/Svg.Editor.Core.Tests/SelectionToolTests.cs
@@ -7,6 +7,8 @@ using Svg.Editor.Events;
 using Svg.Editor.Interfaces;
 using Svg.Editor.Tools;
 using Svg.Interfaces;
+using Svg.Pathing;
+using Svg.Transforms;
 
 namespace Svg.Editor.Core.Test
 {
@@ -188,5 +190,313 @@ namespace Svg.Editor.Core.Test
             Assert.False(Canvas.Document.Children.Any(x => x == element2));
             Assert.AreEqual(0, Canvas.SelectedElements.Count);
         }
+
+        [Test]
+        public async Task PolygonIsSelectedInside_ShouldNotSelect()
+        {
+            // Arrange
+            await Canvas.EnsureInitialized();
+            var tool = Canvas.Tools.OfType<SelectionTool>().Single();
+            Canvas.ActiveTool = tool;
+            Canvas.ScreenWidth = 800;
+            Canvas.ScreenHeight = 500;
+
+
+            var point1 = PointF.Create(0, 400);
+            var point2 = PointF.Create(800, 600);
+            var point3 = PointF.Create(800, 0);
+            var point4 = PointF.Create(-800, 0);
+
+            var collectionPoints = new SvgPointCollection();
+            collectionPoints.AddRange(new SvgUnit[]{point1.X, point1.Y, point2.X, point2.Y, point3.X, point3.Y, point4.X, point4.Y } );
+
+            var polygon = new SvgPolygon()
+            {
+                Points = collectionPoints,
+                Stroke = new SvgColourServer(Color.Create(23, 23, 23)),
+                StrokeWidth = new SvgUnit(SvgUnitType.Pixel, 10),
+                FillOpacity = 0
+            };
+            Canvas.Document.Children.Add(polygon);
+
+            // Preassert
+            Assert.True(Canvas.Document.Children.Any(x => x == polygon));
+
+
+            // Act
+            var pt1 = PointF.Create(400, 350);
+            await Canvas.OnEvent(new PointerEvent(EventType.PointerDown, pt1, pt1, pt1, 1));
+            await Canvas.OnEvent(new PointerEvent(EventType.PointerUp, pt1, pt1, pt1, 1));
+            ((TestScheduler)SchedulerProvider.BackgroundScheduler).AdvanceBy(TimeSpan.FromSeconds(1).Ticks);
+
+            // Assert
+            Assert.AreEqual(0, Canvas.SelectedElements.Count);
+        }
+
+        [Test]
+        public async Task PolygonIsSelectedOutside_ShouldNotSelect()
+        {
+            // Arrange
+            await Canvas.EnsureInitialized();
+            var tool = Canvas.Tools.OfType<SelectionTool>().Single();
+            Canvas.ActiveTool = tool;
+            Canvas.ScreenWidth = 800;
+            Canvas.ScreenHeight = 500;
+
+            var point1 = PointF.Create(100, 200);
+            var point2 = PointF.Create(200, 100);
+            var point3 = PointF.Create(400, 500);
+
+            var collectionPoints = new SvgPointCollection();
+            collectionPoints.AddRange(new SvgUnit[] { point1.X, point1.Y, point2.X, point2.Y, point3.X, point3.Y });
+
+            var polygon = new SvgPolygon()
+            {
+                Points = collectionPoints,
+                StrokeWidth = new SvgUnit(SvgUnitType.Pixel, 10),
+                FillOpacity = 0
+            };
+            Canvas.Document.Children.Add(polygon);
+
+            // Preassert
+            Assert.True(Canvas.Document.Children.Any(x => x == polygon));
+
+
+            // Act
+            var pt1 = PointF.Create(700, 400);
+            await Canvas.OnEvent(new PointerEvent(EventType.PointerDown, pt1, pt1, pt1, 1));
+            await Canvas.OnEvent(new PointerEvent(EventType.PointerUp, pt1, pt1, pt1, 1));
+            ((TestScheduler)SchedulerProvider.BackgroundScheduler).AdvanceBy(TimeSpan.FromSeconds(1).Ticks);
+
+            // Assert
+            Assert.AreEqual(0, Canvas.SelectedElements.Count);
+        }
+
+        [Test]
+        public async Task PolygonIsSelectedOnBorder_ShouldSelect()
+        {
+            // Arrange
+            await Canvas.EnsureInitialized();
+            var tool = Canvas.Tools.OfType<SelectionTool>().Single();
+            Canvas.ActiveTool = tool;
+            Canvas.ScreenWidth = 800;
+            Canvas.ScreenHeight = 500;
+
+            var point1 = PointF.Create(100, 200);
+            var point2 = PointF.Create(200, 100);
+            var point3 = PointF.Create(400, 500);
+
+            var collectionPoints = new SvgPointCollection();
+            collectionPoints.AddRange(new SvgUnit[] { point1.X, point1.Y, point2.X, point2.Y, point3.X, point3.Y });
+
+            var polygon = new SvgPolygon()
+            {
+                Points = collectionPoints,
+                Stroke = new SvgColourServer(Color.Create(23, 23, 23)),
+                StrokeWidth = new SvgUnit(SvgUnitType.Pixel, 10),
+                FillOpacity = 0
+            };
+            Canvas.Document.Children.Add(polygon);
+
+            // Preassert
+            Assert.True(Canvas.Document.Children.Any(x => x == polygon));
+
+
+            // Act
+            var pt1 = PointF.Create(210, 110);
+            var pt2 = PointF.Create(400, 400);
+            await Canvas.OnEvent(new PointerEvent(EventType.PointerDown, pt2, pt2, pt2, 1));
+            await Canvas.OnEvent(new PointerEvent(EventType.PointerUp, pt2, pt2, pt2, 1));
+
+            await Canvas.OnEvent(new PointerEvent(EventType.PointerDown, pt1, pt1, pt1, 1));
+            await Canvas.OnEvent(new PointerEvent(EventType.PointerUp, pt1, pt1, pt1, 1));
+            ((TestScheduler)SchedulerProvider.BackgroundScheduler).AdvanceBy(TimeSpan.FromSeconds(1).Ticks);
+
+            // Assert
+            Assert.AreEqual(1, Canvas.SelectedElements.Count);
+        }
+
+        [Test]
+        public async Task PolygonIsSelected_WhenChildPolygonIsTappedOn_ShouldSelect()
+        {
+            // Arrange
+            await Canvas.EnsureInitialized();
+            var tool = Canvas.Tools.OfType<SelectionTool>().Single();
+            Canvas.ActiveTool = tool;
+            Canvas.ScreenWidth = 800;
+            Canvas.ScreenHeight = 500;
+
+            var point1 = PointF.Create(100, 200);
+            var point2 = PointF.Create(200, 100);
+            var point3 = PointF.Create(400, 500);
+
+            var collectionPoints = new SvgPointCollection();
+            collectionPoints.AddRange(new SvgUnit[] { point1.X, point1.Y, point2.X, point2.Y, point3.X, point3.Y });
+
+            var polygon = new SvgPolygon()
+            {
+                Points = collectionPoints,
+                StrokeWidth = new SvgUnit(SvgUnitType.Pixel, 10),
+                FillOpacity = 0
+            };
+
+            var point4 = PointF.Create(50, 100);
+            var point5 = PointF.Create(100, 500);
+            var point6 = PointF.Create(200, 250);
+
+            var collectionPoints2 = new SvgPointCollection();
+            collectionPoints.AddRange(new SvgUnit[] { point4.X, point4.Y, point5.X, point5.Y, point6.X, point6.Y });
+
+
+            polygon.Children.Add(
+                new SvgPolygon()
+                {
+                    Points = collectionPoints2,
+                    StrokeWidth = new SvgUnit(SvgUnitType.Pixel, 10),
+                    FillOpacity = 0
+                });
+
+            Canvas.Document.Children.Add(polygon);
+
+            // Preassert
+            Assert.True(Canvas.Document.Children.Any(x => x == polygon));
+
+
+            // Act
+            var pt1 = PointF.Create(55, 105);
+            await Canvas.OnEvent(new PointerEvent(EventType.PointerDown, pt1, pt1, pt1, 1));
+            await Canvas.OnEvent(new PointerEvent(EventType.PointerUp, pt1, pt1, pt1, 1));
+            ((TestScheduler)SchedulerProvider.BackgroundScheduler).AdvanceBy(TimeSpan.FromSeconds(1).Ticks);
+
+            // Assert
+            Assert.AreEqual(1, Canvas.SelectedElements.Count);
+        }
+
+        [Test]
+        public async Task PolygonIsSelectedOnVertikalLine_ShouldSelect()
+        {
+            // Arrange
+            await Canvas.EnsureInitialized();
+            var tool = Canvas.Tools.OfType<SelectionTool>().Single();
+            Canvas.ActiveTool = tool;
+            Canvas.ScreenWidth = 800;
+            Canvas.ScreenHeight = 500;
+
+
+            var point1 = PointF.Create(0, 400);
+            var point2 = PointF.Create(800, 600);
+            var point3 = PointF.Create(820, 0);
+            var point4 = PointF.Create(-800, 0);
+
+            var collectionPoints = new SvgPointCollection();
+            collectionPoints.AddRange(new SvgUnit[] { point1.X, point1.Y, point2.X, point2.Y, point3.X, point3.Y, point4.X, point4.Y });
+
+            var polygon = new SvgPolygon()
+            {
+                Points = collectionPoints,
+                Stroke = new SvgColourServer(Color.Create(23, 23, 23)),
+                StrokeWidth = new SvgUnit(SvgUnitType.Pixel, 10),
+                FillOpacity = 0
+            };
+            Canvas.Document.Children.Add(polygon);
+
+            // Preassert
+            Assert.True(Canvas.Document.Children.Any(x => x == polygon));
+
+
+            // Act
+            var pt1 = PointF.Create(800, 400);
+            await Canvas.OnEvent(new PointerEvent(EventType.PointerDown, pt1, pt1, pt1, 1));
+            await Canvas.OnEvent(new PointerEvent(EventType.PointerUp, pt1, pt1, pt1, 1));
+            ((TestScheduler)SchedulerProvider.BackgroundScheduler).AdvanceBy(TimeSpan.FromSeconds(1).Ticks);
+
+            // Assert
+            Assert.AreEqual(1, Canvas.SelectedElements.Count);
+        }
+
+        [Test]
+        public async Task PolygonIsSelectedOnHorizontalLine_ShouldSelect()
+        {
+            // Arrange
+            await Canvas.EnsureInitialized();
+            var tool = Canvas.Tools.OfType<SelectionTool>().Single();
+            Canvas.ActiveTool = tool;
+            Canvas.ScreenWidth = 800;
+            Canvas.ScreenHeight = 500;
+
+
+            var point1 = PointF.Create(0, 400);
+            var point2 = PointF.Create(800, 600);
+            var point3 = PointF.Create(820, 0);
+            var point4 = PointF.Create(-800, 0);
+
+            var collectionPoints = new SvgPointCollection();
+            collectionPoints.AddRange(new SvgUnit[] { point1.X, point1.Y, point2.X, point2.Y, point3.X, point3.Y, point4.X, point4.Y });
+
+            var polygon = new SvgPolygon()
+            {
+                Points = collectionPoints,
+                Stroke = new SvgColourServer(Color.Create(23, 23, 23)),
+                StrokeWidth = new SvgUnit(SvgUnitType.Pixel, 10),
+                FillOpacity = 0
+            };
+            Canvas.Document.Children.Add(polygon);
+
+            // Preassert
+            Assert.True(Canvas.Document.Children.Any(x => x == polygon));
+
+
+            // Act
+            var pt1 = PointF.Create(400, 40);
+            await Canvas.OnEvent(new PointerEvent(EventType.PointerDown, pt1, pt1, pt1, 1));
+            await Canvas.OnEvent(new PointerEvent(EventType.PointerUp, pt1, pt1, pt1, 1));
+            ((TestScheduler)SchedulerProvider.BackgroundScheduler).AdvanceBy(TimeSpan.FromSeconds(1).Ticks);
+
+            // Assert
+            Assert.AreEqual(1, Canvas.SelectedElements.Count);
+        }
+
+        [Test]
+        public async Task PolygonIsSelectedOnHorizontalLine_WhenClickOutsisde_ShouldSelect()
+        {
+            // Arrange
+            await Canvas.EnsureInitialized();
+            var tool = Canvas.Tools.OfType<SelectionTool>().Single();
+            Canvas.ActiveTool = tool;
+            Canvas.ScreenWidth = 800;
+            Canvas.ScreenHeight = 500;
+
+
+            var point1 = PointF.Create(0, 400);
+            var point2 = PointF.Create(800, 600);
+            var point3 = PointF.Create(820, 0);
+            var point4 = PointF.Create(-800, 0);
+
+            var collectionPoints = new SvgPointCollection();
+            collectionPoints.AddRange(new SvgUnit[] { point1.X, point1.Y, point2.X, point2.Y, point3.X, point3.Y, point4.X, point4.Y });
+
+            var polygon = new SvgPolygon()
+            {
+                Points = collectionPoints,
+                Stroke = new SvgColourServer(Color.Create(23, 23, 23)),
+                StrokeWidth = new SvgUnit(SvgUnitType.Pixel, 10),
+                FillOpacity = 0
+            };
+            Canvas.Document.Children.Add(polygon);
+
+            // Preassert
+            Assert.True(Canvas.Document.Children.Any(x => x == polygon));
+
+
+            // Act
+            var pt1 = PointF.Create(400, -40);
+            await Canvas.OnEvent(new PointerEvent(EventType.PointerDown, pt1, pt1, pt1, 1));
+            await Canvas.OnEvent(new PointerEvent(EventType.PointerUp, pt1, pt1, pt1, 1));
+            ((TestScheduler)SchedulerProvider.BackgroundScheduler).AdvanceBy(TimeSpan.FromSeconds(1).Ticks);
+
+            // Assert
+            Assert.AreEqual(1, Canvas.SelectedElements.Count);
+        }
     }
 }
+

--- a/Svg.Editor.Core.Tests/Svg.Editor.Core.Tests.csproj
+++ b/Svg.Editor.Core.Tests/Svg.Editor.Core.Tests.csproj
@@ -56,6 +56,9 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Mono.Android">
+      <HintPath>..\..\..\..\..\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\ReferenceAssemblies\Microsoft\Framework\MonoAndroid\v9.0\Mono.Android.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>

--- a/Svg.Editor.Core/Resources/svg/ic_polygon.svg
+++ b/Svg.Editor.Core/Resources/svg/ic_polygon.svg
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   fill="#000000"
+   height="24"
+   viewBox="0 0 24 24"
+   width="24"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="ic_polygon.svg"
+   inkscape:version="1.2 (dc2aedaf03, 2022-05-15)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="-4.220339"
+     inkscape:cy="15.050847"
+     inkscape:window-width="1920"
+     inkscape:window-height="1129"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <path
+     d="M0 0h24v24H0z"
+     fill="none"
+     id="path4" />
+  <path
+     sodipodi:type="star"
+     style="fill:#000000;fill-opacity:0;stroke:#000000;stroke-width:1.64893507;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+     id="path8364"
+     inkscape:flatsided="true"
+     sodipodi:sides="6"
+     sodipodi:cx="4.4745765"
+     sodipodi:cy="5.0847459"
+     sodipodi:r1="11.390284"
+     sodipodi:r2="9.8642759"
+     sodipodi:arg1="1.0472206"
+     sodipodi:arg2="1.5708193"
+     inkscape:rounded="0"
+     inkscape:randomized="0"
+     d="M 10.169491,14.949152 -1.2207927,14.94889 -6.9157071,5.0844834 -1.220338,-4.7796603 10.169946,-4.7793978 15.86486,5.0850084 Z"
+     transform="matrix(0.95819419,0,0,0.95819419,7.712487,8.2085654)" />
+</svg>

--- a/Svg.Editor.Core/Svg.Editor.Core.csproj
+++ b/Svg.Editor.Core/Svg.Editor.Core.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="Assets\" />
+	  <Folder Include="Assets\" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\svg\ic_arrow_downward.svg" />
@@ -40,6 +40,7 @@
     <EmbeddedResource Include="Resources\svg\ic_pin_resize.svg" />
     <EmbeddedResource Include="Resources\svg\ic_pin_tool.svg" />
     <EmbeddedResource Include="Resources\svg\ic_panorama_fish_eye.svg" />
+    <EmbeddedResource Include="Resources\svg\ic_polygon.svg" />
     <EmbeddedResource Include="Resources\svg\ic_redo.svg" />
     <EmbeddedResource Include="Resources\svg\ic_rotate_left.svg" />
     <EmbeddedResource Include="Resources\svg\ic_rotate_right.svg" />
@@ -60,5 +61,6 @@
     <PackageReference Include="SkiaSharp" Version="1.68.1" />
     <PackageReference Include="Svg" Version="2.4.0.2" />
     <PackageReference Include="System.Reactive" Version="4.0.0" />
+    <PackageReference Include="Xamarin.Forms" Version="4.1.0.778454" />
   </ItemGroup>
 </Project>

--- a/Svg.Editor.Core/Tools/PolygonTool.cs
+++ b/Svg.Editor.Core/Tools/PolygonTool.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Svg.Editor.Gestures;
+using Svg.Editor.Interfaces;
+using Svg.Pathing;
+using PointF = Svg.Interfaces.PointF;
+
+namespace Svg.Editor.Tools
+{
+    public class PolygonTool : UndoableToolBase, ISupportMoving
+    {
+        public PolygonTool(IDictionary<string, object> properties, IUndoRedoService undoRedoService) : base("Polygon",
+            properties, undoRedoService)
+        {
+            IconName = "ic_polygon.svg";
+            ToolUsage = ToolUsage.Explicit;
+            ToolType = ToolType.Create;
+        }
+
+        private const string PolygonTempAttributeKey = "data-polytemp";
+
+        private bool _isActive;
+
+        public override bool IsActive
+        {
+            get => _isActive;
+            set
+            {
+                _isActive = value;
+                if (!value)
+                    Reset();
+            }
+        }
+
+        public override async Task Initialize(ISvgDrawingCanvas ws)
+        {
+            await base.Initialize(ws);
+
+            IsActive = false;
+        }
+
+        public const string DefaultStrokeWidthKey = "defaultstrokewidth";
+
+        public int DefaultStrokeWidth
+        {
+            get
+            {
+                object defaultStrokeWidth;
+                return Properties.TryGetValue(DefaultStrokeWidthKey, out defaultStrokeWidth)
+                    ? Convert.ToInt32(defaultStrokeWidth)
+                    : 2;
+            }
+            set => Properties[DefaultStrokeWidthKey] = value;
+        }
+        public IList<PointF> Points { get; } = new List<PointF>();
+        protected override async Task OnTap(TapGesture tap)
+        {
+            await base.OnTap(tap);
+
+            var point = Canvas.ScreenToCanvas(tap.Position);
+
+            if (!IsActive) return;
+
+            Canvas.SelectedElements.Clear();
+
+            if (Points.Count > 0)
+            {
+                //Closing the polygon
+                if (IsClickingOnFirstPoint(point))
+                {
+                    var ls = new SvgLineSegment(Points.Last(), Points.First());
+                    
+                    DrawPolygon();
+                    Reset();
+                    Canvas.ActiveTool = Canvas.Tools.First(tool => tool.Name == "Select");
+                }
+                else
+                {
+                    DrawVector(Points.Last(), point);
+                }
+            }
+            else
+            {
+                DrawPoint(point);
+                Points.Add(point);
+            }
+
+            Canvas.FireInvalidateCanvas();
+        }
+
+        private bool IsClickingOnFirstPoint(PointF tapPoint)
+        {
+            var point = Points.First();
+
+            return point.X >= tapPoint.X - 10 / Canvas.ZoomFactor &&
+                   point.X <= tapPoint.X + 10 / Canvas.ZoomFactor &&
+                   point.Y >= tapPoint.Y - 10 / Canvas.ZoomFactor &&
+                   point.Y <= tapPoint.Y + 10 / Canvas.ZoomFactor;
+        }
+
+        private void DrawPoint(PointF point)
+        {
+            var circle = new SvgCircle()
+            {
+                CenterX = point.X,
+                CenterY = point.Y,
+                Radius = 5,
+                FillOpacity = 0.75f,
+                StrokeOpacity = 0.75f
+            };
+            circle.CustomAttributes[PolygonTempAttributeKey] = "";
+
+            Canvas.Document.Children.Add(circle);
+        }
+
+        private void DrawVector(PointF start, PointF end)
+        {
+            Points.Add(end);
+
+            var line = new SvgLine()
+            {
+                StartX = start.X,
+                EndX = end.X,
+                StartY = start.Y,
+                EndY = end.Y,
+                StrokeOpacity = 0.5f
+            };
+            line.CustomAttributes[PolygonTempAttributeKey] = "";
+
+            Canvas.Document.Children.Add(line);
+        }
+
+        private void DrawPolygon()
+        {
+            var points = Points.SelectMany(p => new SvgUnit[] { p.X, p.Y });
+            var collectionPoints = new SvgPointCollection();
+            collectionPoints.AddRange(points);
+
+            var polygon = new SvgPolygon()
+            {
+                Points = collectionPoints,
+                StrokeWidth = new SvgUnit(SvgUnitType.Pixel, DefaultStrokeWidth),
+                FillOpacity = 0
+            };
+
+            Canvas.Document.Children.Add(polygon);
+        }
+
+        public override void Reset()
+        {
+            var toDelete = Canvas.Document.Children.Where(c => c.CustomAttributes.ContainsKey(PolygonTempAttributeKey))
+                .ToList();
+
+            toDelete.ForEach(item => Canvas.Document.Children.Remove(item));
+
+            Points.Clear();
+
+        }
+    }
+}

--- a/Svg.Editor.Core/Tools/SelectionTool.cs
+++ b/Svg.Editor.Core/Tools/SelectionTool.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using Svg.Editor.Gestures;
 using Svg.Editor.Interfaces;
 using Svg.Editor.UndoRedo;
 using Svg.Interfaces;
+
 
 namespace Svg.Editor.Tools
 {
@@ -195,7 +198,7 @@ namespace Svg.Editor.Tools
 
         #region Private helpers
 
-        private static void SelectElementsUnder(RectangleF selectionRectangle, ISvgDrawingCanvas ws, SelectionType selectionType, int maxItems = int.MaxValue)
+        private void SelectElementsUnder(RectangleF selectionRectangle, ISvgDrawingCanvas ws, SelectionType selectionType, int maxItems = int.MaxValue)
         {
             ws.SelectedElements.Clear();
 
@@ -203,13 +206,137 @@ namespace Svg.Editor.Tools
             // we need to compare our rectangle to the translated boundingboxes of the svg elements
             var selected = ws.GetElementsUnder<SvgVisualElement>(selectionRectangle, selectionType, maxItems);
 
+            var canvasPoint = ws.ScreenToCanvas(PointF.Create(selectionRectangle.X+selectionRectangle.Width/2, selectionRectangle.Y+selectionRectangle.Height/2));
+
+            if (!Canvas.Document.Children.Contains(_dumm))
+                Canvas.Document.Children.Add(_dumm);
+
+            _dumm.CenterX = canvasPoint.X;
+            _dumm.CenterY = canvasPoint.Y;
+
             foreach (var element in selected)
             {
+                if (element is SvgPolygon poly && selectionRectangle.Height <= 20 && selectionRectangle.Width <= 20)
+                {
+                    if (element.Stroke != null && element.Stroke.ToString() != "" && element.FillOpacity == 0)
+                        if (!ValidatePolygonSelection((SvgPolygon)element, canvasPoint, 40 / ws.ZoomFactor))
+                            break;
+                }
+
                 if (element.CustomAttributes.ContainsKey(BackgroundCustomAttributeKey)) continue;
                 ws.SelectedElements.Add(element);
             }
         }
 
-        #endregion
+        protected bool ValidatePolygonSelection(SvgPolygon polygon, PointF tap, double selectionFuzzines)
+        {
+            if (polygon == null)
+                return false;
+
+            
+            var m = Matrix.Create();
+            var allTransForms = polygon.Parents.Reverse().Concat(new[] { polygon }).SelectMany(elt => elt.Transforms)
+                .ToList();
+
+            foreach (var t in allTransForms)
+                t.ApplyTo(m);
+
+            var units = polygon.Points.ToList();
+
+            PointF firstPoint = PointF.Empty;
+            PointF lastPoint = PointF.Empty;
+            for (var i = 0; i < units.Count-3; i+=2)
+            {
+                PointF[] points = new[]
+                {
+                    PointF.Create(units[i].Value, units[i+1].Value),
+                    PointF.Create(units[i + 2].Value, units[i + 3].Value),
+                };
+
+                m.TransformPoints(points);
+
+                if (TapedOnBorder(points[0], points[1], tap, selectionFuzzines))
+                    return true;
+
+                if (i == 0)
+                {
+                    firstPoint = points[0];
+                }
+                lastPoint = points[1];
+            }
+
+            return TapedOnBorder(lastPoint, firstPoint, tap, selectionFuzzines);
+        }
+
+        /// <summary>
+        /// Google paste https://stackoverflow.com/a/13741803/333571
+        /// </summary>
+        /// <param name="start"></param>
+        /// <param name="end"></param>
+        /// <param name="point"></param>
+        /// <param name="selectionFuzzines"></param>
+        /// <returns></returns>
+        private bool TapedOnBorder(PointF start, PointF end, PointF point, double selectionFuzzines)
+        {
+            PointF leftPoint;
+            PointF rightPoint;
+
+            // Normalize start/end to left right to make the offset calc simpler.
+            if (start.X <= end.X)
+            {
+                leftPoint = start;
+                rightPoint = end;
+            }
+            else
+            {
+                leftPoint = end;
+                rightPoint = start;
+            }
+
+            // If point is out of bounds, no need to do further checks.                  
+            if (point.X + selectionFuzzines < leftPoint.X || rightPoint.X < point.X - selectionFuzzines)
+                return false;
+            if (point.Y + selectionFuzzines < Math.Min(leftPoint.Y, rightPoint.Y) || Math.Max(leftPoint.Y, rightPoint.Y) < point.Y - selectionFuzzines)
+                return false;
+
+            // https://de.wikipedia.org/wiki/Lineare_Funktion
+            double deltaX = rightPoint.X - leftPoint.X;
+            double deltaY = rightPoint.Y - leftPoint.Y;
+
+            // If the line is straight, the earlier boundary check is enough to determine that the point is on the line.
+            // Also prevents division by zero exceptions.
+            if (deltaX == 0 || deltaY == 0)
+                return true;
+
+            double slope = deltaY / deltaX;
+            double offset = leftPoint.Y - leftPoint.X * slope;
+            double calculatedY = point.X * slope + offset;
+
+            //adjustment of offset 
+            double c = point.Y - offset - slope * point.X;
+
+            double actualX = (point.Y - offset) / slope;
+            double outOfBounds = point.X - actualX >= 0 ? point.X - actualX : actualX - point.X;
+
+            if (outOfBounds > selectionFuzzines && c > selectionFuzzines) {
+                    return false;
+            }
+            
+            calculatedY += c;
+
+            //Check calculated Y matches the points Y coord with some easing.
+            bool lineContains = point.Y - selectionFuzzines <= calculatedY && calculatedY <= point.Y + selectionFuzzines;
+
+            return lineContains;
+        }
+
+        private SvgCircle _dumm = new SvgCircle
+        {
+            Radius = 5,
+            Fill = new SvgColourServer(Color.Create("#FF0000"))
+        };
     }
+
+    #endregion
+    
 }

--- a/Svg.Editor.Sample.Forms/Svg.Editor.Sample.Forms/MainViewModel.cs
+++ b/Svg.Editor.Sample.Forms/Svg.Editor.Sample.Forms/MainViewModel.cs
@@ -101,6 +101,11 @@ namespace Svg.Editor.Sample.Forms
                 {"pinsizenames", new[] {"Small", "Medium", "Large", "ExtraLarge" } }
             };
 
+            var polygonProperties = new Dictionary<string, object>
+            {
+                {"submit", false }
+            };
+
             #endregion
 
             DrawingCanvas = new SvgDrawingCanvas();
@@ -123,6 +128,7 @@ namespace Svg.Editor.Sample.Forms
 		        () => new SaveTool(false),
 		        () => new PlaceAsBackgroundTool(placeAsBackgroundToolProperties, undoRedoService),
 		        () => new AddItemTool(),
+		        () => new PolygonTool(polygonProperties, undoRedoService),
                 () => new PinTool(pinToolProperties, undoRedoService));
         }
 


### PR DESCRIPTION
## Selection Hittest Status

Die aktuelle Selektierung von einem Polygon sollte funktionieren. Mit der Hilfe zweier Punkte kann man eine Lineare funktion, y = k(slope) *x + d(offset), aufstellen. Das reicht aber nicht da der y-Wert vom geklickten Punkt nicht den selben Wert entspricht. Das Offset war also nicht richtig. Ich hab neue Funktion, y = k * x + d + c, auf c umgeformt und somit das Adjustmet für den y-Wert bekommen. Wir haben jetzt die neue Position der Linie und müssen dann nur noch checken, ob sich die Linie nicht außerhalb der fuzzines befindet. (Erstes Diagramm am Foto).    

1. Problem ( Zweites Diagramm am Foto)
Wenn eine Linie Horizontal oder Vertikal mit dem Winkel 0 ist. Dann ist die selectionRectangle kleiner als die fuzziness und somit außerhalb des Polygons nicht klickbar. Das macht auch keinen Sinn weil ich kann nich einfach irgendwo ins Leere klicken und etwas wird ausgewählt.

2. Problem
Abfrage ob ein Polygon ein Child hat, dass auch ein Polygon ist und dann Parent anklicken.

![selection](https://user-images.githubusercontent.com/44953551/187936747-9e7862b1-8bdf-455a-86a0-7c2abe440192.png)
