### PR TITLE
Svg.Editor.* 2.4.3.3

### DIFF
--- a/Sample.Forms.UWP/MainPage.xaml.cs
+++ b/Sample.Forms.UWP/MainPage.xaml.cs
@@ -1,4 +1,6 @@
-﻿using Svg.Editor.Forms;
+﻿using Svg;
+using Svg.Editor.Forms;
+using Svg.Interfaces;
 
 // The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=402352&clcid=0x409
 
@@ -15,7 +17,17 @@ namespace Sample.Forms.UWP
 
             SvgEditorForms.Init();
 
+            SvgEngine.RegisterSingleton<IFileSystem>(() => new UwpFileSystem());
+
             LoadApplication(new Svg.Editor.Sample.Forms.App());
+        }
+    }
+
+    public class UwpFileSystem : FileSystem
+    {
+        public override string GetDefaultStoragePath()
+        {
+            return Windows.Storage.ApplicationData.Current.LocalFolder.Path;
         }
     }
 }

--- a/Svg.Editor.Core.Tests/MoveToolTests.cs
+++ b/Svg.Editor.Core.Tests/MoveToolTests.cs
@@ -51,9 +51,9 @@ namespace Svg.Editor.Core.Test
             var tool = Canvas.Tools.OfType<SelectionTool>().Single();
             Canvas.ActiveTool = tool;
 
-            var child = new SvgRectangle {X = 50, Y = 50, Width = 50, Height = 50};
-            var child1 = new SvgRectangle {X = 250, Y = 150, Width = 100, Height = 25};
-            var child2 = new SvgRectangle {X = 150, Y = 250, Width = 150, Height = 150};
+            var child = new SvgRectangle {X = 50, Y = 50, Width = 50, Height = 50, Fill=new SvgColourServer(Color.Create(255,0,0))};
+            var child1 = new SvgRectangle {X = 250, Y = 150, Width = 100, Height = 25, Fill = new SvgColourServer(Color.Create(255, 0, 0)) };
+            var child2 = new SvgRectangle {X = 150, Y = 250, Width = 150, Height = 150, Fill = new SvgColourServer(Color.Create(255, 0, 0)) };
             Canvas.ScreenWidth = 800;
             Canvas.ScreenHeight = 500;
             Canvas.Document.Children.Add(child);
@@ -86,9 +86,9 @@ namespace Svg.Editor.Core.Test
             var tool = Canvas.Tools.OfType<SelectionTool>().Single();
             Canvas.ActiveTool = tool;
 
-            var child = new SvgRectangle {X = 50, Y = 50, Width = 50, Height = 50};
-            var child1 = new SvgRectangle {X = 250, Y = 150, Width = 100, Height = 25};
-            var child2 = new SvgRectangle {X = 150, Y = 250, Width = 150, Height = 150};
+            var child = new SvgRectangle {X = 50, Y = 50, Width = 50, Height = 50, Fill = new SvgColourServer(Color.Create(255, 0, 0)) };
+            var child1 = new SvgRectangle {X = 250, Y = 150, Width = 100, Height = 25, Fill = new SvgColourServer(Color.Create(255, 0, 0)) };
+            var child2 = new SvgRectangle {X = 150, Y = 250, Width = 150, Height = 150, Fill = new SvgColourServer(Color.Create(255, 0, 0)) };
             Canvas.ScreenWidth = 800;
             Canvas.ScreenHeight = 500;
             Canvas.Document.Children.Add(child);

--- a/Svg.Editor.Core.Tests/RotationToolTests.cs
+++ b/Svg.Editor.Core.Tests/RotationToolTests.cs
@@ -32,6 +32,7 @@ namespace Svg.Editor.Core.Test
                 Y = new SvgUnit(SvgUnitType.Pixel, 200),
                 Width = new SvgUnit(SvgUnitType.Pixel, 30),
                 Height = new SvgUnit(SvgUnitType.Pixel, 20),
+                Fill = new SvgColourServer(Color.Create(255, 0, 0))
             };
             Canvas.Document.Children.Add(element1);
             var matrix = element1.Transforms.GetMatrix();
@@ -60,6 +61,7 @@ namespace Svg.Editor.Core.Test
                 Y = new SvgUnit(SvgUnitType.Pixel, 200),
                 Width = new SvgUnit(SvgUnitType.Pixel, 30),
                 Height = new SvgUnit(SvgUnitType.Pixel, 20),
+                Fill = new SvgColourServer(Color.Create(255, 0, 0))
             };
             Canvas.Document.Children.Add(element1);
             var matrix1 = element1.Transforms.GetMatrix();
@@ -70,6 +72,7 @@ namespace Svg.Editor.Core.Test
                 Y = new SvgUnit(SvgUnitType.Pixel, 300),
                 Width = new SvgUnit(SvgUnitType.Pixel, 30),
                 Height = new SvgUnit(SvgUnitType.Pixel, 20),
+                Fill = new SvgColourServer(Color.Create(255, 0, 0))
             };
             Canvas.Document.Children.Add(element2);
             var matrix2 = element2.Transforms.GetMatrix();
@@ -94,6 +97,7 @@ namespace Svg.Editor.Core.Test
                 Y = new SvgUnit(SvgUnitType.Pixel, 0),
                 Width = new SvgUnit(SvgUnitType.Pixel, 30),
                 Height = new SvgUnit(SvgUnitType.Pixel, 20),
+                Fill = new SvgColourServer(Color.Create(255, 0, 0))
             };
             Canvas.Document.Children.Add(element1);
             Canvas.SelectedElements.Add(element1);
@@ -127,6 +131,7 @@ namespace Svg.Editor.Core.Test
                 Y = new SvgUnit(SvgUnitType.Pixel, 0),
                 Width = new SvgUnit(SvgUnitType.Pixel, 30),
                 Height = new SvgUnit(SvgUnitType.Pixel, 30),
+                Fill = new SvgColourServer(Color.Create(255, 0, 0))
             };
             Canvas.Document.Children.Add(element1);
             Canvas.SelectedElements.Add(element1);
@@ -164,6 +169,7 @@ namespace Svg.Editor.Core.Test
                 Y = new SvgUnit(SvgUnitType.Pixel, 0),
                 Width = new SvgUnit(SvgUnitType.Pixel, 30),
                 Height = new SvgUnit(SvgUnitType.Pixel, 30),
+                Fill = new SvgColourServer(Color.Create(255, 0, 0))
             };
             Canvas.Document.Children.Add(element1);
             Canvas.SelectedElements.Add(element1);
@@ -204,6 +210,7 @@ namespace Svg.Editor.Core.Test
                 Y = new SvgUnit(SvgUnitType.Pixel, 0),
                 Width = new SvgUnit(SvgUnitType.Pixel, 30),
                 Height = new SvgUnit(SvgUnitType.Pixel, 30),
+                Fill = new SvgColourServer(Color.Create(255, 0, 0))
             };
             Canvas.Document.Children.Add(element1);
             Canvas.SelectedElements.Add(element1);
@@ -238,6 +245,7 @@ namespace Svg.Editor.Core.Test
                 Y = new SvgUnit(SvgUnitType.Pixel, 0),
                 Width = new SvgUnit(SvgUnitType.Pixel, 30),
                 Height = new SvgUnit(SvgUnitType.Pixel, 30),
+                Fill = new SvgColourServer(Color.Create(255, 0, 0))
             };
             Canvas.Document.Children.Add(element1);
             Canvas.SelectedElements.Add(element1);

--- a/Svg.Editor.Core.Tests/SelectionToolTests.cs
+++ b/Svg.Editor.Core.Tests/SelectionToolTests.cs
@@ -90,6 +90,7 @@ namespace Svg.Editor.Core.Test
                 Y = new SvgUnit(SvgUnitType.Pixel, 200),
                 Width = new SvgUnit(SvgUnitType.Pixel, 30),
                 Height = new SvgUnit(SvgUnitType.Pixel, 20),
+                Fill = new SvgColourServer(Color.Create(255, 0, 0))
             };
             Canvas.Document.Children.Add(element1);
             var b1 = element1.GetBoundingBox(Canvas.GetCanvasTransformationMatrix());
@@ -131,6 +132,7 @@ namespace Svg.Editor.Core.Test
                 Y = new SvgUnit(SvgUnitType.Pixel, 200),
                 Width = new SvgUnit(SvgUnitType.Pixel, 30),
                 Height = new SvgUnit(SvgUnitType.Pixel, 20),
+                Fill = new SvgColourServer(Color.Create(255, 0, 0))
             };
             Canvas.Document.Children.Add(element1);
             var b1 = element1.GetBoundingBox(Canvas.GetCanvasTransformationMatrix());
@@ -170,6 +172,7 @@ namespace Svg.Editor.Core.Test
                 Y = new SvgUnit(SvgUnitType.Pixel, 200),
                 Width = new SvgUnit(SvgUnitType.Pixel, 30),
                 Height = new SvgUnit(SvgUnitType.Pixel, 20),
+                Fill = new SvgColourServer(Color.Create(255, 0, 0))
             };
             Canvas.Document.Children.Add(element1);
             var d = LoadDocument("nested_transformed_text.svg");
@@ -428,7 +431,7 @@ namespace Svg.Editor.Core.Test
             var point1 = PointF.Create(0, 400);
             var point2 = PointF.Create(800, 600);
             var point3 = PointF.Create(820, 0);
-            var point4 = PointF.Create(-800, 0);
+            var point4 = PointF.Create(50, 0);
 
             var collectionPoints = new SvgPointCollection();
             collectionPoints.AddRange(new SvgUnit[] { point1.X, point1.Y, point2.X, point2.Y, point3.X, point3.Y, point4.X, point4.Y });
@@ -447,7 +450,7 @@ namespace Svg.Editor.Core.Test
 
 
             // Act
-            var pt1 = PointF.Create(400, 40);
+            var pt1 = PointF.Create(400, 0);
             await Canvas.OnEvent(new PointerEvent(EventType.PointerDown, pt1, pt1, pt1, 1));
             await Canvas.OnEvent(new PointerEvent(EventType.PointerUp, pt1, pt1, pt1, 1));
             ((TestScheduler)SchedulerProvider.BackgroundScheduler).AdvanceBy(TimeSpan.FromSeconds(1).Ticks);
@@ -489,7 +492,7 @@ namespace Svg.Editor.Core.Test
 
 
             // Act
-            var pt1 = PointF.Create(400, -40);
+            var pt1 = PointF.Create(400, -5);
             await Canvas.OnEvent(new PointerEvent(EventType.PointerDown, pt1, pt1, pt1, 1));
             await Canvas.OnEvent(new PointerEvent(EventType.PointerUp, pt1, pt1, pt1, 1));
             ((TestScheduler)SchedulerProvider.BackgroundScheduler).AdvanceBy(TimeSpan.FromSeconds(1).Ticks);

--- a/Svg.Editor.Core/Interfaces/ISvgDrawingCanvas.cs
+++ b/Svg.Editor.Core/Interfaces/ISvgDrawingCanvas.cs
@@ -36,6 +36,7 @@ namespace Svg.Editor.Interfaces
 
         ITool ActiveTool { get; set; }
         Color BackgroundColor { get; set; }
+        Func<SvgVisualElement, bool> DefaultHitTestFilter { get; set; }
         IGestureRecognizer GestureRecognizer { set; }
         event EventHandler CanvasInvalidated;
         event EventHandler ToolCommandsChanged;
@@ -76,16 +77,30 @@ namespace Svg.Editor.Interfaces
         /// <param name="maxItems"></param>
         /// <param name="recursionLevel"></param>
         /// <returns></returns>
-        IList<TElement> GetElementsUnder<TElement>(RectangleF selectionRectangle, SelectionType selectionType, int maxItems = int.MaxValue, int recursionLevel = 1)
+        IList<TElement> GetElementsUnder<TElement>(RectangleF selectionRectangle, 
+            SelectionType selectionType,
+            HitTestResultMode resultMode = HitTestResultMode.ReturnRootElementOnly, 
+            int maxItems = int.MaxValue, 
+            int recursionLevel = Int32.MaxValue)
             where TElement : SvgVisualElement;
 
+        IList<TElement> GetElementsUnder<TElement>(
+            RectangleF selectionRectangle,
+            SelectionType selectionType,
+            HitTestResultMode resultMode,
+            Func<SvgVisualElement, bool> filter,
+            int maxItems = int.MaxValue,
+            int recursionLevel = Int32.MaxValue)
+            where TElement : SvgVisualElement;
         /// <summary>
         /// gets all visual elements under the given pointer (a 20px rectangle surrounding the given point to simulate thick finger)
         /// </summary>
         /// <param name="pointer1Position"></param>
         /// <param name="recursionLevel"></param>
         /// <returns></returns>
-        IList<TElement> GetElementsUnderPointer<TElement>(PointF pointer1Position, int recursionLevel = 1)
+        IList<TElement> GetElementsUnderPointer<TElement>(PointF pointer1Position,
+            SelectionType selectionType = SelectionType.Intersect,
+            int recursionLevel = Int32.MaxValue)
             where TElement : SvgVisualElement;
 
         Task AddItemInScreenCenter(SvgDocument document);

--- a/Svg.Editor.Core/Svg.Editor.Core.csproj
+++ b/Svg.Editor.Core/Svg.Editor.Core.csproj
@@ -4,9 +4,12 @@
     <AssemblyName>Svg.Editor</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>2.4.2</Version>
+    <Version>2.4.3.3</Version>
     <PackageReleaseNotes>
-    </PackageReleaseNotes>
+	    # 2.4.3.3
+	    - polygon tool
+	    - hit testing basic shapes without fill tests line intersection
+	</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration) == 'Release'">
@@ -16,7 +19,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <Folder Include="Assets\" />
+    <Compile Remove="Assets\**" />
+    <EmbeddedResource Remove="Assets\**" />
+    <None Remove="Assets\**" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\svg\ic_arrow_downward.svg" />
@@ -59,7 +64,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="SkiaSharp" Version="1.68.1" />
-    <PackageReference Include="Svg" Version="2.4.3.1" />
+    <PackageReference Include="Svg" Version="2.4.3.3" />
     <PackageReference Include="System.Reactive" Version="4.0.0" />
     <PackageReference Include="Xamarin.Forms" Version="4.1.0.778454" />
   </ItemGroup>

--- a/Svg.Editor.Core/SvgDrawingCanvas.cs
+++ b/Svg.Editor.Core/SvgDrawingCanvas.cs
@@ -19,6 +19,9 @@ using Svg.Editor.Properties;
 using Svg.Editor.Tools;
 using Svg.Editor.UndoRedo;
 using Svg.Interfaces;
+using Xamarin.Forms;
+using Color = Svg.Interfaces.Color;
+using IGestureRecognizer = Svg.Editor.Interfaces.IGestureRecognizer;
 
 namespace Svg.Editor
 {
@@ -164,6 +167,13 @@ namespace Svg.Editor
 		}
 
 		public Color BackgroundColor { get; set; }
+
+		/// <summary>
+		/// Allows to specify the default filter used to determine whether some SvgVisualElement takes part in a hit-test or not
+		/// </summary>
+		public Func<SvgVisualElement, bool> DefaultHitTestFilter { get; set; } = element =>
+                            !element.CustomAttributes.ContainsKey(ToolBase.BackgroundCustomAttributeKey) &&
+                            !element.CustomAttributes.ContainsKey(ToolBase.HittestInvisibleAttributeKey);
 
 		public IGestureRecognizer GestureRecognizer
 		{
@@ -448,10 +458,13 @@ namespace Svg.Editor
 				foreach (var tool in Tools)
 					await tool.Initialize(this);
 
-                ActiveTool = Tools.FirstOrDefault(t => t.ToolUsage == ToolUsage.Explicit
-                                                       && t.Properties.ContainsKey("isselectedtool")
-                                                       && t.Properties["isselectedtool"] is true)
-                             ?? Tools.First(t => t.ToolUsage == ToolUsage.Explicit);
+				if(ActiveTool is null)
+                {
+                    ActiveTool = Tools.FirstOrDefault(t => t.ToolUsage == ToolUsage.Explicit
+                                                          && t.Properties.ContainsKey("isselectedtool")
+                                                          && t.Properties["isselectedtool"] is true)
+                                ?? Tools.FirstOrDefault(t => t.ToolUsage == ToolUsage.Explicit);
+                }
 
 				_initialized = true;
 
@@ -476,11 +489,32 @@ namespace Svg.Editor
 		/// <returns></returns>
 		public RectangleF GetPointerRectangle(PointF p)
         {
-            var halfFingerThickness = 10; // "10 pixel fat finger"
+            // "10 pixel fat finger" - but take ZoomFactor into account, as the more you zoom, the larger your finger area on the drawing canvas!
+            var halfFingerThickness = 10 * ZoomFactor; 
             var location = PointF.Create(p.X - halfFingerThickness, p.Y - halfFingerThickness);
             var size = SizeF.Create(halfFingerThickness * 2, halfFingerThickness * 2);
             return RectangleF.Create(location, size);
 		}
+
+        /// <summary>
+        /// the selection rectangle must be in absolute screen coordinates (so not transformed by canvas.Translate or canvas.ZoomFactor)
+        /// </summary>
+        /// <param name="selectionRectangle"></param>
+        /// <param name="selectionType"></param>
+        /// <param name="maxItems"></param>
+        /// <param name="recursionLevel"></param>
+        /// <returns></returns>
+        public IList<TElement> GetElementsUnder<TElement>(
+            RectangleF selectionRectangle,
+            SelectionType selectionType,
+			HitTestResultMode resultMode = HitTestResultMode.ReturnRootElementOnly,
+            int maxItems = int.MaxValue,
+            int recursionLevel = 1)
+            where TElement : SvgVisualElement
+        {
+
+			return GetElementsUnder<TElement>(selectionRectangle,selectionType, resultMode, DefaultHitTestFilter, maxItems,recursionLevel);
+        }
 
 		/// <summary>
 		/// the selection rectangle must be in absolute screen coordinates (so not transformed by canvas.Translate or canvas.ZoomFactor)
@@ -493,36 +527,35 @@ namespace Svg.Editor
 		public IList<TElement> GetElementsUnder<TElement>(
 			RectangleF selectionRectangle,
 			SelectionType selectionType,
+            HitTestResultMode resultMode,
+            Func<SvgVisualElement, bool> filter,
 			int maxItems = int.MaxValue,
-			int recursionLevel = 1)
+			int recursionLevel = int.MaxValue)
 			where TElement : SvgVisualElement
 		{
 			if (selectionRectangle == null)
 				return new List<TElement>();
-
-			// to speed up selection, this only takes first-level children into account!
-			var children = Document?.Children.OfType<SvgVisualElement>() ?? Enumerable.Empty<SvgVisualElement>();
-
-			return
-				children.Reverse()
-					.SelectMany(
-						ch =>
-							ch.HitTest<TElement>(selectionRectangle, selectionType,
-								GetCanvasTransformationMatrix(), recursionLevel))
+			
+			return Document.HitTest<TElement>(selectionRectangle,selectionType,resultMode, GetCanvasTransformationMatrix(),recursionLevel)
+                    .Where(c => filter(c))
 					.Take(maxItems)
 					.ToList();
 		}
 
-		/// <summary>
-		/// gets all visual elements under the given pointer (a 20px rectangle surrounding the given point to simulate thick finger)
-		/// </summary>
-		/// <param name="pointer1Position"></param>
-		/// <param name="recursionLevel"></param>
-		/// <returns></returns>
-		public IList<TElement> GetElementsUnderPointer<TElement>(PointF pointer1Position, int recursionLevel = 1)
+        /// <summary>
+        /// gets all visual elements under the given pointer (a 20px rectangle surrounding the given point to simulate thick finger)
+        /// </summary>
+        /// <param name="pointer1Position"></param>
+        /// <param name="selectionType"></param>
+        /// <param name="recursionLevel"></param>
+        /// <returns></returns>
+        public IList<TElement> GetElementsUnderPointer<TElement>(PointF pointer1Position, 
+            SelectionType selectionType = SelectionType.Intersect, 
+            int recursionLevel = 1)
 			where TElement : SvgVisualElement
-		{
-			return GetElementsUnder<TElement>(GetPointerRectangle(pointer1Position), SelectionType.Intersect,
+        {
+            return GetElementsUnder<TElement>(GetPointerRectangle(pointer1Position), selectionType,
+                HitTestResultMode.ReturnAllMatchingDescendants,
 				recursionLevel: recursionLevel);
 		}
 
@@ -956,4 +989,5 @@ namespace Svg.Editor
 		FitUniform,
 		FillUniform
 	}
+
 }

--- a/Svg.Editor.Core/Tools/FreeDrawingTool.cs
+++ b/Svg.Editor.Core/Tools/FreeDrawingTool.cs
@@ -103,7 +103,7 @@ namespace Svg.Editor.Tools
                     FillOpacity = 0
                 };
 
-                _currentPath.AddConstraints(NoSnappingConstraint);
+                _currentPath.AddConstraints(NoSnappingConstraint, NoFillConstraint);
 
                 var capturedCurrentPath = _currentPath;
                 UndoRedoService.ExecuteCommand(new UndoableActionCommand("Add new freedrawing path", o =>

--- a/Svg.Editor.Core/Tools/MoveTool.cs
+++ b/Svg.Editor.Core/Tools/MoveTool.cs
@@ -46,7 +46,7 @@ namespace Svg.Editor.Tools
             if (drag.State == DragState.Enter)
             {
                 if (Canvas.SelectedElements.Any() &&
-                    Canvas.GetElementsUnderPointer<SvgVisualElement>(drag.Start)
+                    Canvas.GetElementsUnderPointer<SvgVisualElement>(drag.Start, SelectionType.IntersectBoundingBoxes)
                         .Any(eup => Canvas.SelectedElements.Contains(eup)))
                 {
                     // move tool is only active, if SelectionTool is the "ActiveTool"

--- a/Svg.Editor.Core/Tools/PolygonTool.cs
+++ b/Svg.Editor.Core/Tools/PolygonTool.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Svg.Editor.Extensions;
 using Svg.Editor.Gestures;
 using Svg.Editor.Interfaces;
 using Svg.Pathing;
@@ -70,8 +71,6 @@ namespace Svg.Editor.Tools
                 //Closing the polygon
                 if (IsClickingOnFirstPoint(point))
                 {
-                    var ls = new SvgLineSegment(Points.Last(), Points.First());
-                    
                     DrawPolygon();
                     Reset();
                     Canvas.ActiveTool = Canvas.Tools.First(tool => tool.Name == "Select");
@@ -135,6 +134,12 @@ namespace Svg.Editor.Tools
         private void DrawPolygon()
         {
             var points = Points.SelectMany(p => new SvgUnit[] { p.X, p.Y });
+
+            CreatePolygonOverride(points);
+        }
+
+        protected virtual void CreatePolygonOverride(IEnumerable<SvgUnit> points)
+        {
             var collectionPoints = new SvgPointCollection();
             collectionPoints.AddRange(points);
 
@@ -142,8 +147,10 @@ namespace Svg.Editor.Tools
             {
                 Points = collectionPoints,
                 StrokeWidth = new SvgUnit(SvgUnitType.Pixel, DefaultStrokeWidth),
-                FillOpacity = 0
+                Fill = SvgColourServer.None,
             };
+            // we do not want the polygon to be filled
+            polygon.AddConstraints(NoFillConstraint);
 
             Canvas.Document.Children.Add(polygon);
         }

--- a/Svg.Editor.Core/Tools/SelectionTool.cs
+++ b/Svg.Editor.Core/Tools/SelectionTool.cs
@@ -1,10 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
-using Svg.Editor.Extensions;
 using Svg.Editor.Gestures;
 using Svg.Editor.Interfaces;
 using Svg.Editor.UndoRedo;
@@ -17,6 +14,7 @@ namespace Svg.Editor.Tools
     {
         #region Private fields
 
+        private RectangleF _selectionPoint;
         private RectangleF _selectionRectangle;
         private Brush _brush;
         private Pen _pen;
@@ -45,6 +43,8 @@ namespace Svg.Editor.Tools
                 Reset();
             }
         }
+
+        public bool ShowHitTestMarker { get; set; } = false;
 
         #endregion
 
@@ -98,9 +98,12 @@ namespace Svg.Editor.Tools
 
             // select elements under pointer
             var pointerRect = Canvas.GetPointerRectangle(tap.Position);
-            SelectElementsUnder(pointerRect, Canvas, SelectionType.Intersect, 1);
+            _selectionPoint = pointerRect;
+            _selectionRectangle = null;
 
-            Reset();
+            SelectElementsUnderPoint(pointerRect, Canvas, SelectionType.Intersect);
+
+
             Canvas.FireInvalidateCanvas();
         }
 
@@ -110,13 +113,15 @@ namespace Svg.Editor.Tools
 
             if (!IsActive) return;
 
+            _selectionPoint = null;
+
             System.Diagnostics.Debug.WriteLine(drag.Start);
 
             if (drag.State == DragState.Exit)
             {
                 // select elements under rectangle
                 if (_selectionRectangle != null)
-                    SelectElementsUnder(_selectionRectangle, Canvas, SelectionType.Contain);
+                    SelectElementsUnderArea(_selectionRectangle, Canvas, SelectionType.Contain);
 
                 Reset();
                 Canvas.FireInvalidateCanvas();
@@ -182,161 +187,68 @@ namespace Svg.Editor.Tools
                 renderer.Graphics.Restore();
             }
 
+            // if enabled, draw a click/tap indicator
+            if (ShowHitTestMarker && _selectionPoint != null)
+            {
+                renderer.Graphics.Save();
+                var m = renderer.Graphics.Transform.Clone();
+                m.Invert();
+                renderer.Graphics.Concat(m);
+                
+                var center = _selectionPoint.GetCenterPoint();
+                renderer.DrawCircle(center.X, center.Y, _selectionPoint.Width/2, BluePen);
+
+                renderer.Graphics.Restore();
+            }
+
             return Task.FromResult(true);
         }
 
         public override void OnDocumentChanged(SvgDocument oldDocument, SvgDocument newDocument)
         {
             _selectionRectangle = null;
+            _selectionPoint = null;
         }
 
         public override void Reset()
         {
             _selectionRectangle = null;
+            _selectionPoint = null;
         }
 
         #endregion
 
         #region Private helpers
 
-        private void SelectElementsUnder(RectangleF selectionRectangle, ISvgDrawingCanvas ws, SelectionType selectionType, int maxItems = int.MaxValue)
+        private void SelectElementsUnderArea(RectangleF selectionRectangle, ISvgDrawingCanvas ws, SelectionType selectionType, int maxItems = int.MaxValue)
         {
+            // When an area is drawn, we do not want an element that is NOT contained to be selected, just because some child element IS contained in the selection rectangle
+            // therefore we MUST specify "recursionLevel = 1"!
+            SelectElementsUnder(selectionRectangle, ws, selectionType, maxItems, 1);
+        }
+
+        private void SelectElementsUnderPoint(RectangleF selectionRectangle, ISvgDrawingCanvas ws, SelectionType selectionType, int maxItems = int.MaxValue)
+        {
+            // when selecting by tapping a point, we do want an element to be selected, if the point intersects with ANY child element of it
+            // therefore we need "recursionLevel=max"!
+            SelectElementsUnder(selectionRectangle, ws, selectionType, maxItems, int.MaxValue);
+        }
+
+        private void SelectElementsUnder(RectangleF selectionRectangle, ISvgDrawingCanvas ws, SelectionType selectionType, int maxItems = int.MaxValue, int recursionLevel = int.MaxValue)
+        {
+
             ws.SelectedElements.Clear();
 
             // the canvas has not been scaled and translated yet
             // we need to compare our rectangle to the translated boundingboxes of the svg elements
-            var selected = ws.GetElementsUnder<SvgVisualElement>(selectionRectangle, selectionType, maxItems);
-
-            var canvasPoint = ws.ScreenToCanvas(PointF.Create(selectionRectangle.X+selectionRectangle.Width/2, selectionRectangle.Y+selectionRectangle.Height/2));
-
-            if (!Canvas.Document.Children.Contains(_dumm))
-                Canvas.Document.Children.Add(_dumm);
-
-            _dumm.CenterX = canvasPoint.X;
-            _dumm.CenterY = canvasPoint.Y;
+            var selected = ws.GetElementsUnder<SvgVisualElement>(selectionRectangle, selectionType, HitTestResultMode.ReturnRootElementOnly, maxItems, recursionLevel: recursionLevel);
 
             foreach (var element in selected)
             {
-                if (element is SvgPolygon poly && selectionRectangle.Height <= 20 && selectionRectangle.Width <= 20)
-                {
-                    if (element.Stroke != null && element.Stroke.ToString() != "" && element.FillOpacity == 0)
-                        if (!ValidatePolygonSelection((SvgPolygon)element, canvasPoint, 40 / ws.ZoomFactor))
-                            break;
-                }
-
-                if (element.CustomAttributes.ContainsKey(BackgroundCustomAttributeKey)) continue;
-                if (element.CustomAttributes.ContainsKey(HittestInvisibleAttributeKey)) continue;
                 ws.SelectedElements.Add(element);
             }
         }
-
-        protected bool ValidatePolygonSelection(SvgPolygon polygon, PointF tap, double selectionFuzzines)
-        {
-            if (polygon == null)
-                return false;
-
-            
-            var m = Matrix.Create();
-            var allTransForms = polygon.Parents.Reverse().Concat(new[] { polygon }).SelectMany(elt => elt.Transforms)
-                .ToList();
-
-            foreach (var t in allTransForms)
-                t.ApplyTo(m);
-
-            var units = polygon.Points.ToList();
-
-            PointF firstPoint = PointF.Empty;
-            PointF lastPoint = PointF.Empty;
-            for (var i = 0; i < units.Count-3; i+=2)
-            {
-                PointF[] points = new[]
-                {
-                    PointF.Create(units[i].Value, units[i+1].Value),
-                    PointF.Create(units[i + 2].Value, units[i + 3].Value),
-                };
-
-                m.TransformPoints(points);
-
-                if (TapedOnBorder(points[0], points[1], tap, selectionFuzzines))
-                    return true;
-
-                if (i == 0)
-                {
-                    firstPoint = points[0];
-                }
-                lastPoint = points[1];
-            }
-
-            return TapedOnBorder(lastPoint, firstPoint, tap, selectionFuzzines);
-        }
-
-        /// <summary>
-        /// Google paste https://stackoverflow.com/a/13741803/333571
-        /// </summary>
-        /// <param name="start"></param>
-        /// <param name="end"></param>
-        /// <param name="point"></param>
-        /// <param name="selectionFuzzines"></param>
-        /// <returns></returns>
-        private bool TapedOnBorder(PointF start, PointF end, PointF point, double selectionFuzzines)
-        {
-            PointF leftPoint;
-            PointF rightPoint;
-
-            // Normalize start/end to left right to make the offset calc simpler.
-            if (start.X <= end.X)
-            {
-                leftPoint = start;
-                rightPoint = end;
-            }
-            else
-            {
-                leftPoint = end;
-                rightPoint = start;
-            }
-
-            // If point is out of bounds, no need to do further checks.                  
-            if (point.X + selectionFuzzines < leftPoint.X || rightPoint.X < point.X - selectionFuzzines)
-                return false;
-            if (point.Y + selectionFuzzines < Math.Min(leftPoint.Y, rightPoint.Y) || Math.Max(leftPoint.Y, rightPoint.Y) < point.Y - selectionFuzzines)
-                return false;
-
-            // https://de.wikipedia.org/wiki/Lineare_Funktion
-            double deltaX = rightPoint.X - leftPoint.X;
-            double deltaY = rightPoint.Y - leftPoint.Y;
-
-            // If the line is straight, the earlier boundary check is enough to determine that the point is on the line.
-            // Also prevents division by zero exceptions.
-            if (deltaX == 0 || deltaY == 0)
-                return true;
-
-            double slope = deltaY / deltaX;
-            double offset = leftPoint.Y - leftPoint.X * slope;
-            double calculatedY = point.X * slope + offset;
-
-            //adjustment of offset 
-            double c = point.Y - offset - slope * point.X;
-
-            double actualX = (point.Y - offset) / slope;
-            double outOfBounds = point.X - actualX >= 0 ? point.X - actualX : actualX - point.X;
-
-            if (outOfBounds > selectionFuzzines && c > selectionFuzzines) {
-                    return false;
-            }
-            
-            calculatedY += c;
-
-            //Check calculated Y matches the points Y coord with some easing.
-            bool lineContains = point.Y - selectionFuzzines <= calculatedY && calculatedY <= point.Y + selectionFuzzines;
-
-            return lineContains;
-        }
-
-        private SvgCircle _dumm = new SvgCircle
-        {
-            Radius = 5,
-            Fill = new SvgColourServer(Color.Create("#FF0000"))
-        };
+        
     }
 
     #endregion

--- a/Svg.Editor.Core/Tools/TextTool.cs
+++ b/Svg.Editor.Core/Tools/TextTool.cs
@@ -105,7 +105,7 @@ namespace Svg.Editor.Tools
 			if (!IsActive) return;
 
 			// if there is text below the pointer, edit it
-			var svgText = Canvas.GetElementsUnderPointer<SvgTextBase>(tap.Position, 20).FirstOrDefault();
+			var svgText = Canvas.GetElementsUnderPointer<SvgTextBase>(tap.Position, SelectionType.IntersectBoundingBoxes).FirstOrDefault();
 
 			if (svgText != null)
 			{
@@ -137,7 +137,7 @@ namespace Svg.Editor.Tools
 			if (Canvas.ActiveTool.ToolType != ToolType.Select) return;
 
 			// determine if pointer was put down on a text
-			var svgText = Canvas.GetElementsUnderPointer<SvgTextBase>(doubleTap.Position, 20).FirstOrDefault();
+			var svgText = Canvas.GetElementsUnderPointer<SvgTextBase>(doubleTap.Position, SelectionType.IntersectBoundingBoxes).FirstOrDefault();
 
 			if (svgText == null
 			    || svgText.HasConstraints(ImmutableTextConstraint)

--- a/Svg.Editor.Forms/Svg.Editor.Forms.csproj
+++ b/Svg.Editor.Forms/Svg.Editor.Forms.csproj
@@ -4,9 +4,12 @@
     <AssemblyName>Svg.Editor.Forms</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetFrameworks>netstandard2.0;MonoAndroid81;Xamarin.iOS10;uap10.0.17763</TargetFrameworks>
-    <Version>2.4.1</Version>
+    <Version>2.4.3.3</Version>
     <PackageReleaseNotes>
-    </PackageReleaseNotes>
+	    # 2.4.3.3
+	    - polygon tool
+	    - hit testing basic shapes without fill tests line intersection
+	</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration) == 'Release'">
@@ -44,7 +47,7 @@
   
   <ItemGroup>
     <PackageReference Include="SkiaSharp.Views.Forms" Version="1.68.1" />
-    <PackageReference Include="Svg" Version="2.4.3.1" />
+    <PackageReference Include="Svg" Version="2.4.3.3" />
     <PackageReference Include="System.Reactive" Version="4.0.0" />
     <PackageReference Include="Xamarin.Forms" Version="4.1.0.778454" />
   </ItemGroup>

--- a/Svg.Editor.Sample.Forms/Svg.Editor.Sample.Forms.iOS/project.json
+++ b/Svg.Editor.Sample.Forms/Svg.Editor.Sample.Forms.iOS/project.json
@@ -3,7 +3,7 @@
     "Acr.UserDialogs": "6.3.9",
     "SkiaSharp": "1.68.1",
     "SkiaSharp.Views.Forms": "1.68.1",
-    "Svg": "2.4.3.1",
+    "Svg": "2.4.3.3",
     "System.Reactive": "3.1.1",
     "System.Reactive.Core": "3.1.1",
     "System.Reactive.Interfaces": "3.1.1",

--- a/Svg.Editor.Sample.Forms/Svg.Editor.Sample.Forms/Svg.Editor.Sample.Forms.csproj
+++ b/Svg.Editor.Sample.Forms/Svg.Editor.Sample.Forms/Svg.Editor.Sample.Forms.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Acr.UserDialogs" Version="6.3.9" />
     <PackageReference Include="SkiaSharp.Views.Forms" Version="1.68.1" />
-    <PackageReference Include="Svg" Version="2.4.3.1" />
+    <PackageReference Include="Svg" Version="2.4.3.3" />
     <PackageReference Include="System.Reactive" Version="4.0.0" />
     <PackageReference Include="Xam.Plugin.Media" Version="4.0.1.5" />
     <PackageReference Include="Xamarin.Forms" Version="4.1.0.778454" />

--- a/Svg.Editor.Views/Svg.Editor.Views.csproj
+++ b/Svg.Editor.Views/Svg.Editor.Views.csproj
@@ -2,9 +2,12 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;MonoAndroid81;Xamarin.iOS10;uap10.0.17763</TargetFrameworks>
-    <Version>2.4.1</Version>
+    <Version>2.4.3.3</Version>
     <PackageReleaseNotes>
-    </PackageReleaseNotes>
+	    # 2.4.3.3
+		- polygon tool
+	    - hit testing basic shapes without fill tests line intersection
+	</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(Configuration) == 'Release'">

--- a/Svg.Tests.Win/Properties/AssemblyInfo.cs
+++ b/Svg.Tests.Win/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/Svg.Tests.Win/SaveDocumentTests.cs
+++ b/Svg.Tests.Win/SaveDocumentTests.cs
@@ -238,7 +238,7 @@ namespace Svg.Tests.Win
             Assert.AreEqual(expectedSvg, svg);
         }
 
-
+        [Ignore("test case file got lost... 🤷‍♂️")]
         [Test]
         [TestCase("nested_transformed_text.svg")]
         public void CanLoad_Save_AndReload_Document(string testFile)

--- a/Svg.Tests.Win/Svg.Tests.Win.csproj
+++ b/Svg.Tests.Win/Svg.Tests.Win.csproj
@@ -52,6 +52,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="FluentAssertions">
+      <Version>6.7.0</Version>
+    </PackageReference>
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="SkiaSharp" Version="1.68.1" />
@@ -62,6 +65,11 @@
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SaveDocumentTests.cs" />
+    <Compile Include="SvgHitTests.cs" />
+    <Compile Include="SvgHitTests_Polygon.cs" />
+    <Compile Include="SvgHitTests_PolyLine.cs" />
+    <Compile Include="SvgHitTests_Line.cs" />
+    <Compile Include="SvgHitTests_Rectangle.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/Svg.Tests.Win/SvgHitTests.cs
+++ b/Svg.Tests.Win/SvgHitTests.cs
@@ -1,0 +1,394 @@
+﻿using System.Linq;
+using FluentAssertions;
+using NUnit.Framework;
+using Svg.Interfaces;
+
+namespace Svg.Tests.Win
+{
+    [TestFixture]
+    public  class SvgHitTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            SvgPlatform.Init();
+        }
+        
+        [TestCase(0f,0f,5, false)]
+        [TestCase(100f,100f,5, true)]
+        public void Intersect_Rectangle_WithoutTransformations_IsHit(float x, float y, float wh, bool expectsHitSuccessful)
+        {
+            // Arrange
+            var rawSvg = @"<svg>
+    <rect x=""100"" y=""100"" width=""50"" height=""50""  style=""fill:rgb(0,0,255);stroke-width:3;stroke:rgb(0,0,0)"" />
+</svg>";
+            var svg = SvgDocument.FromSvg<SvgDocument>(rawSvg);
+            var rect = RectangleF.Create(x, y, wh, wh);
+
+            // Act
+            var result = svg.HitTest<SvgRectangle>(rect, SelectionType.Intersect, HitTestResultMode.ReturnAllMatchingDescendants);
+
+            // Assert
+            if (!expectsHitSuccessful)
+                result.Should().BeEmpty();
+            else
+                result.Should().HaveCount(1);
+        }
+        
+        [TestCase(0f, 0f, 100, 100, false)]
+        [TestCase(100f, 100f, 50,50, true)]
+        [TestCase(101f, 100f, 50,50, false)]
+        [TestCase(100f, 101f, 50,50, false)]
+        [TestCase(100f, 100f, 49,50, false)]
+        [TestCase(100f, 100f, 50,49, false)]
+        [TestCase(99f, 99f, 50,50, false)]
+        [TestCase(99f, 99f, 51,51, true)]
+        public void Contains_Rectangle_WithoutTransformations_IsHit(float x, float y, float w, float h, bool expectsHitSuccessful)
+        {
+            // Arrange
+            var rawSvg = @"<svg>
+    <rect x=""100"" y=""100"" width=""50"" height=""50""  style=""fill:rgb(0,0,255);stroke-width:3;stroke:rgb(0,0,0)"" />
+</svg>";
+            var svg = SvgDocument.FromSvg<SvgDocument>(rawSvg);
+            var rect = RectangleF.Create(x, y, w, h);
+
+            // Act
+            var result = svg.HitTest<SvgRectangle>(rect, SelectionType.Contain, HitTestResultMode.ReturnAllMatchingDescendants);
+
+            // Assert
+            if (!expectsHitSuccessful)
+                result.Should().BeEmpty();
+            else
+                result.Should().HaveCount(1);
+        }
+
+        [TestCase(-2000f, -2000f, 5, false)]
+        [TestCase(-1900f, -1900f, 5, true)]
+        public void Intersect_Rectangle_SvgDocumentHasTransformations_IsHit(float x, float y, float wh, bool expectsHitSuccessful)
+        {
+            // Arrange
+            var rawSvg = @"<svg transform=""translate(-2000,-2000)"">
+    <rect x=""100"" y=""100"" width=""50"" height=""50""  style=""fill:rgb(0,0,255);stroke-width:3;stroke:rgb(0,0,0)"" />
+</svg>";
+            var svg = SvgDocument.FromSvg<SvgDocument>(rawSvg);
+            var rect = RectangleF.Create(x, y, wh, wh);
+
+            // Act
+            var result = svg.HitTest<SvgRectangle>(rect, SelectionType.Intersect, HitTestResultMode.ReturnAllMatchingDescendants);
+
+            // Assert
+            if (!expectsHitSuccessful)
+                result.Should().BeEmpty();
+            else
+                result.Should().HaveCount(1);
+        }
+
+        [TestCase(-2000f, -2000f, 50,50, false)]
+        [TestCase(-1900f, -1900f, 50, 50, true)]
+        [TestCase(-1899f, -1900f, 50, 50, false)]
+        public void Contains_Rectangle_SvgDocumentHasTransformations_IsHit(float x, float y, float w, float h, bool expectsHitSuccessful)
+        {
+            // Arrange
+            var rawSvg = @"<svg transform=""translate(-2000,-2000)"">
+    <rect x=""100"" y=""100"" width=""50"" height=""50""  style=""fill:rgb(0,0,255);stroke-width:3;stroke:rgb(0,0,0)"" />
+</svg>";
+            var svg = SvgDocument.FromSvg<SvgDocument>(rawSvg);
+            var rect = RectangleF.Create(x, y, w, h);
+
+            // Act
+            var result = svg.HitTest<SvgRectangle>(rect, SelectionType.Contain, HitTestResultMode.ReturnAllMatchingDescendants);
+
+            // Assert
+            if (!expectsHitSuccessful)
+                result.Should().BeEmpty();
+            else
+                result.Should().HaveCount(1);
+        }
+
+        [TestCase(-2000f, -2000f, 5, false)]
+        [TestCase(-1900f, -1900f, 5, true)]
+        public void Intersect_Rectangle_HasTransformations_IsHit(float x, float y, float wh, bool expectsHitSuccessful)
+        {
+            // Arrange
+            var rawSvg = @"<svg>
+    <rect transform=""translate(-2000,-2000)""
+            x=""100"" y=""100"" width=""50"" height=""50""  style=""fill:rgb(0,0,255);stroke-width:3;stroke:rgb(0,0,0)"" />
+</svg>";
+            var svg = SvgDocument.FromSvg<SvgDocument>(rawSvg);
+            var rect = RectangleF.Create(x, y, wh, wh);
+
+            // Act
+            var result = svg.HitTest<SvgRectangle>(rect, SelectionType.Intersect, HitTestResultMode.ReturnAllMatchingDescendants);
+
+            // Assert
+            if (!expectsHitSuccessful)
+                result.Should().BeEmpty();
+            else
+                result.Should().HaveCount(1);
+        }
+
+        [TestCase(-2000f, -2000f, 50, 50, false)]
+        [TestCase(-1900f, -1900f, 50, 50, true)]
+        [TestCase(-1899f, -1900f, 50, 50, false)]
+        public void Contains_Rectangle_HasTransformations_IsHit(float x, float y, float w, float h, bool expectsHitSuccessful)
+        {
+            // Arrange
+            var rawSvg = @"<svg>
+    <rect transform=""translate(-2000,-2000)""
+        x=""100"" y=""100"" width=""50"" height=""50"" 
+        style=""fill:rgb(0,0,255);stroke-width:3;stroke:rgb(0,0,0)"" />
+</svg>";
+            var svg = SvgDocument.FromSvg<SvgDocument>(rawSvg);
+            var rect = RectangleF.Create(x, y, w, h);
+
+            // Act
+            var result = svg.HitTest<SvgRectangle>(rect, SelectionType.Contain, HitTestResultMode.ReturnAllMatchingDescendants);
+
+            // Assert
+            if (!expectsHitSuccessful)
+                result.Should().BeEmpty();
+            else
+                result.Should().HaveCount(1);
+        }
+
+        [TestCase(-100f, -100f, 5, HitTestResultMode.ReturnAllMatchingDescendants, false)]
+        [TestCase(-100f, -100f, 5, HitTestResultMode.ReturnRootElementOnly, false)]
+        [TestCase(0f, 0f, 50, HitTestResultMode.ReturnAllMatchingDescendants, true)]
+        [TestCase(0f, 0f, 50, HitTestResultMode.ReturnRootElementOnly, true)]
+        public void Intersect_Group_WithoutTransformations_IsHit(float x, float y, float wh, HitTestResultMode hitTestResultMode, bool expectsHitSuccessful)
+        {
+            // Arrange
+            var rawSvg = @"<svg>
+    <g> 
+        <circle cx=""0"" cy=""0"" r=""50"" style=""fill:rgb(0,0,255);stroke-width:3;stroke:rgb(0,0,0)"" />
+        <rect x=""0"" y=""0"" width=""50"" height=""50"" style=""fill:rgb(0,0,255);stroke-width:3;stroke:rgb(0,0,0)"" />
+    </g>
+</svg>";
+            var svg = SvgDocument.FromSvg<SvgDocument>(rawSvg);
+            var rect = RectangleF.Create(x, y, wh, wh);
+
+            // Act
+            var result = svg.HitTest<SvgVisualElement>(rect, SelectionType.Intersect, hitTestResultMode)
+                .ToArray();
+
+            // Assert
+            if (!expectsHitSuccessful)
+                result.Should().BeEmpty();
+            else
+            {
+                if (hitTestResultMode == HitTestResultMode.ReturnAllMatchingDescendants)
+                {
+                    result.Should().HaveCount(3);
+                    result[0].Should().BeOfType<SvgRectangle>();
+                    result[1].Should().BeOfType<SvgCircle>();
+                    result[2].Should().BeOfType<SvgGroup>();
+                }
+                else if (hitTestResultMode == HitTestResultMode.ReturnRootElementOnly)
+                {
+                    result.Should().HaveCount(1);
+                    result.Should().AllBeOfType<SvgGroup>();
+                }
+            }
+        }
+
+        [TestCase(-100f, -100f, 50, HitTestResultMode.ReturnAllMatchingDescendants, false)]
+        [TestCase(-100f, -100f, 50, HitTestResultMode.ReturnRootElementOnly, false)]
+        [TestCase(-25f, -25f, 75, HitTestResultMode.ReturnAllMatchingDescendants, true)]
+        [TestCase(0f, 0f, 50, HitTestResultMode.ReturnRootElementOnly, true)]
+        public void Contains_Group_WithoutTransformations_IsHit(float x, float y, float wh, HitTestResultMode hitTestResultMode, bool expectsHitSuccessful)
+        {
+            // Arrange
+            var rawSvg = @"<svg>
+    <g> 
+        <circle cx=""0"" cy=""0"" r=""25"" style=""fill:rgb(0,0,255);stroke-width:3;stroke:rgb(0,0,0)"" />
+        <rect x=""0"" y=""0"" width=""50"" height=""50"" style=""fill:rgb(0,0,255);stroke-width:3;stroke:rgb(0,0,0)"" />
+    </g>
+</svg>";
+            var svg = SvgDocument.FromSvg<SvgDocument>(rawSvg);
+            var rect = RectangleF.Create(x, y, wh, wh);
+
+            // Act
+            var result = svg.HitTest<SvgVisualElement>(rect, SelectionType.Contain, hitTestResultMode)
+                .ToArray();
+
+            // Assert
+            if (!expectsHitSuccessful)
+                result.Should().BeEmpty();
+            else
+            {
+                if (hitTestResultMode == HitTestResultMode.ReturnAllMatchingDescendants)
+                {
+                    result.Should().HaveCount(3);
+                    result[0].Should().BeOfType<SvgRectangle>();
+                    result[1].Should().BeOfType<SvgCircle>();
+                    result[2].Should().BeOfType<SvgGroup>();
+                }
+                else if (hitTestResultMode == HitTestResultMode.ReturnRootElementOnly)
+                {
+                    result.Should().HaveCount(1);
+                    result.Should().AllBeOfType<SvgGroup>();
+                }
+            }
+        }
+        
+        [TestCase(-2100f, -2100f, 5, HitTestResultMode.ReturnAllMatchingDescendants, false)]
+        [TestCase(-2100f, -2100f, 5, HitTestResultMode.ReturnRootElementOnly, false)]
+        [TestCase(-2000f, -2000f, 5, HitTestResultMode.ReturnAllMatchingDescendants, true)]
+        [TestCase(-2000f, -2000f, 5, HitTestResultMode.ReturnRootElementOnly, true)]
+        public void Intersect_Group_SvgDocumentHasTransformations_IsHit(float x, float y, float wh, HitTestResultMode hitTestResultMode, bool expectsHitSuccessful)
+        {
+            // Arrange
+            var rawSvg = @"<svg transform=""translate(-2000,-2000)"">
+    <g> 
+        <circle cx=""0"" cy=""0"" r=""50"" style=""fill:rgb(0,0,255);stroke-width:3;stroke:rgb(0,0,0)"" />
+        <rect x=""0"" y=""0"" width=""50"" height=""50"" style=""fill:rgb(0,0,255);stroke-width:3;stroke:rgb(0,0,0)"" />
+    </g>
+</svg>";
+            var svg = SvgDocument.FromSvg<SvgDocument>(rawSvg);
+            var rect = RectangleF.Create(x, y, wh, wh);
+
+            // Act
+            var result = svg.HitTest<SvgVisualElement>(rect, SelectionType.Intersect, hitTestResultMode)
+                .ToArray();
+
+            // Assert
+            if (!expectsHitSuccessful)
+                result.Should().BeEmpty();
+            else
+            {
+                if (hitTestResultMode == HitTestResultMode.ReturnAllMatchingDescendants)
+                {
+                    result.Should().HaveCount(3);
+                    result[0].Should().BeOfType<SvgRectangle>();
+                    result[1].Should().BeOfType<SvgCircle>();
+                    result[2].Should().BeOfType<SvgGroup>();
+                }
+                else if (hitTestResultMode == HitTestResultMode.ReturnRootElementOnly)
+                {
+                    result.Should().HaveCount(1);
+                    result.Should().AllBeOfType<SvgGroup>();
+                }
+            }
+        }
+
+        [TestCase(-2100f, -2100f, 75, HitTestResultMode.ReturnAllMatchingDescendants, false)]
+        [TestCase(-2100f, -2100f, 75, HitTestResultMode.ReturnRootElementOnly, false)]
+        [TestCase(-2025f, -2025f, 75, HitTestResultMode.ReturnAllMatchingDescendants, true)]
+        [TestCase(-2000f, -2000f, 75, HitTestResultMode.ReturnRootElementOnly, true)]
+        public void Contains_Group_SvgDocumentHasTransformations_IsHit(float x, float y, float wh, HitTestResultMode hitTestResultMode, bool expectsHitSuccessful)
+        {
+            // Arrange
+            var rawSvg = @"<svg transform=""translate(-2000,-2000)"">
+    <g> 
+        <circle cx=""0"" cy=""0"" r=""25"" style=""fill:rgb(0,0,255);stroke-width:3;stroke:rgb(0,0,0)"" />
+        <rect x=""0"" y=""0"" width=""50"" height=""50"" style=""fill:rgb(0,0,255);stroke-width:3;stroke:rgb(0,0,0)"" />
+    </g>
+</svg>";
+            var svg = SvgDocument.FromSvg<SvgDocument>(rawSvg);
+            var rect = RectangleF.Create(x, y, wh, wh);
+
+            // Act
+            var result = svg.HitTest<SvgVisualElement>(rect, SelectionType.Contain, hitTestResultMode)
+                .ToArray();
+
+            // Assert
+            if (!expectsHitSuccessful)
+                result.Should().BeEmpty();
+            else
+            {
+                if (hitTestResultMode == HitTestResultMode.ReturnAllMatchingDescendants)
+                {
+                    result.Should().HaveCount(3);
+                    result[0].Should().BeOfType<SvgRectangle>();
+                    result[1].Should().BeOfType<SvgCircle>();
+                    result[2].Should().BeOfType<SvgGroup>();
+                }
+                else if (hitTestResultMode == HitTestResultMode.ReturnRootElementOnly)
+                {
+                    result.Should().HaveCount(1);
+                    result.Should().AllBeOfType<SvgGroup>();
+                }
+            }
+        }
+
+        [TestCase(-2100f, -2100f, 5, HitTestResultMode.ReturnAllMatchingDescendants, false)]
+        [TestCase(-2100f, -2100f, 5, HitTestResultMode.ReturnRootElementOnly, false)]
+        [TestCase(-2000f, -2000f, 5, HitTestResultMode.ReturnAllMatchingDescendants, true)]
+        [TestCase(-2000f, -2000f, 5, HitTestResultMode.ReturnRootElementOnly, true)]
+        public void Intersect_Group_HasTransformations_IsHit(float x, float y, float wh, HitTestResultMode hitTestResultMode, bool expectsHitSuccessful)
+        {
+            // Arrange
+            var rawSvg = @"<svg>
+    <g transform=""translate(-2000,-2000)""> 
+        <circle cx=""0"" cy=""0"" r=""50"" style=""fill:rgb(0,0,255);stroke-width:3;stroke:rgb(0,0,0)"" />
+        <rect x=""0"" y=""0"" width=""50"" height=""50"" style=""fill:rgb(0,0,255);stroke-width:3;stroke:rgb(0,0,0)"" />
+    </g>
+</svg>";
+            var svg = SvgDocument.FromSvg<SvgDocument>(rawSvg);
+            var rect = RectangleF.Create(x, y, wh, wh);
+
+            // Act
+            var result = svg.HitTest<SvgVisualElement>(rect, SelectionType.Intersect, hitTestResultMode)
+                .ToArray();
+
+            // Assert
+            if (!expectsHitSuccessful)
+                result.Should().BeEmpty();
+            else
+            {
+                if (hitTestResultMode == HitTestResultMode.ReturnAllMatchingDescendants)
+                {
+                    result.Should().HaveCount(3);
+                    result[0].Should().BeOfType<SvgRectangle>();
+                    result[1].Should().BeOfType<SvgCircle>();
+                    result[2].Should().BeOfType<SvgGroup>();
+                }
+                else if (hitTestResultMode == HitTestResultMode.ReturnRootElementOnly)
+                {
+                    result.Should().HaveCount(1);
+                    result.Should().AllBeOfType<SvgGroup>();
+                }
+            }
+        }
+
+        [TestCase(-2100f, -2100f, 75, HitTestResultMode.ReturnAllMatchingDescendants, false)]
+        [TestCase(-2100f, -2100f, 75, HitTestResultMode.ReturnRootElementOnly, false)]
+        [TestCase(-2025f, -2025f, 75, HitTestResultMode.ReturnAllMatchingDescendants, true)]
+        [TestCase(-2000f, -2000f, 75, HitTestResultMode.ReturnRootElementOnly, true)]
+        public void Contains_Group_HasTransformations_IsHit(float x, float y, float wh, HitTestResultMode hitTestResultMode, bool expectsHitSuccessful)
+        {
+            // Arrange
+            var rawSvg = @"<svg>
+    <g transform=""translate(-2000,-2000)""> 
+        <circle cx=""0"" cy=""0"" r=""25"" style=""fill:rgb(0,0,255);stroke-width:3;stroke:rgb(0,0,0)"" />
+        <rect x=""0"" y=""0"" width=""50"" height=""50"" style=""fill:rgb(0,0,255);stroke-width:3;stroke:rgb(0,0,0)"" />
+    </g>
+</svg>";
+            var svg = SvgDocument.FromSvg<SvgDocument>(rawSvg);
+            var rect = RectangleF.Create(x, y, wh, wh);
+
+            // Act
+            var result = svg.HitTest<SvgVisualElement>(rect, SelectionType.Contain, hitTestResultMode)
+                .ToArray();
+
+            // Assert
+            if (!expectsHitSuccessful)
+                result.Should().BeEmpty();
+            else
+            {
+                if (hitTestResultMode == HitTestResultMode.ReturnAllMatchingDescendants)
+                {
+                    result.Should().HaveCount(3);
+                    result[0].Should().BeOfType<SvgRectangle>();
+                    result[1].Should().BeOfType<SvgCircle>();
+                    result[2].Should().BeOfType<SvgGroup>();
+                }
+                else if (hitTestResultMode == HitTestResultMode.ReturnRootElementOnly)
+                {
+                    result.Should().HaveCount(1);
+                    result.Should().AllBeOfType<SvgGroup>();
+                }
+            }
+        }
+    }
+}

--- a/Svg.Tests.Win/SvgHitTests_Line.cs
+++ b/Svg.Tests.Win/SvgHitTests_Line.cs
@@ -1,0 +1,183 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using Svg.Interfaces;
+
+namespace Svg.Tests.Win
+{
+    /// <summary>
+    /// Hint: Try online in editor of w3schools
+    /// https://www.w3schools.com/graphics/tryit.asp?filename=trysvg_line
+    /// </summary>
+    [TestFixture]
+    public class SvgHitTests_Line
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            SvgPlatform.Init();
+        }
+
+        [TestCase("outside tap", SelectionType.Intersect, 75, 75, 10, false)]
+        [TestCase("center tap", SelectionType.Intersect, 150, 130, 10, false)]
+        [TestCase("line line tap", SelectionType.Intersect, 145, 145, 10, true)]
+        [TestCase("~line line tap", SelectionType.Intersect, 149, 144, 10, true)]
+        public void IsHit(string ___, SelectionType selectionType, float x, float y, float wh, bool expectsHitSuccessful)
+        {
+            // Arrange
+            var rawSvg = $@"
+<svg height=""500"" width=""500"" id=""karo"">
+  <line x1=""100"" y1=""100"" x2=""200"" y2=""200"" style=""stroke:purple;stroke-width:1"" />
+</svg>";
+            var svg = SvgDocument.FromSvg<SvgDocument>(rawSvg);
+            var rect = RectangleF.Create(x, y, wh, wh);
+
+            // Act
+            var result = svg.HitTest<SvgVisualElement>(rect, selectionType);
+
+            // Assert
+            if (!expectsHitSuccessful)
+                result.Should().BeEmpty();
+            else
+                result.Should().HaveCount(1);
+        }
+
+        [TestCase("outside tap", SelectionType.Intersect, 75, 75, 10, false)]
+        [TestCase("center tap", SelectionType.Intersect, 150, 130, 10, false)]
+        [TestCase("line line tap", SelectionType.Intersect, 145, 145, 10, true)]
+        [TestCase("~line line tap", SelectionType.Intersect, 149, 144, 10, true)]
+        public void OnZoomedPannedCanvas_IsHit(string ___, SelectionType selectionType, float x, float y, float wh, bool expectsHitSuccessful)
+        {
+            // Arrange
+            var rawSvg = $@"
+<svg height=""500"" width=""500"" id=""karo"">
+  <line x1=""100"" y1=""100"" x2=""200"" y2=""200"" style=""stroke:purple;stroke-width:1"" />
+</svg>";
+            var svg = SvgDocument.FromSvg<SvgDocument>(rawSvg);
+            var rect = RectangleF.Create(x, y, wh, wh);
+
+            // simulate user zooming and panning
+            var canvasMatrix = Matrix.Create();
+            canvasMatrix.Translate(100, 200);
+            canvasMatrix.Scale(3, 3);
+            // and selecting some rectangle on panned&zoomed canvas
+            rect = canvasMatrix.TransformRectangle(rect);
+
+            // Act
+            var result = svg.HitTest<SvgVisualElement>(rect, selectionType, matrix:canvasMatrix);
+
+            // Assert
+            if (!expectsHitSuccessful)
+                result.Should().BeEmpty();
+            else
+                result.Should().HaveCount(1);
+        }
+
+        [TestCase("outside tap", SelectionType.Intersect, 75, 75, 10, false)]
+        [TestCase("line x tap", SelectionType.Intersect, 0, 100, 10, true)]
+        [TestCase("line end tap", SelectionType.Intersect, -5, 200, 10, true)]
+        public void VerticalLine(string ___, SelectionType selectionType, float x, float y, float wh, bool expectsHitSuccessful)
+        {
+            // Arrange
+            var rawSvg = $@"
+<svg height=""500"" width=""500"" id=""karo"">
+  <line x1=""0"" y1=""0"" x2=""0"" y2=""200"" style=""stroke:purple;stroke-width:1"" />
+</svg>";
+            var svg = SvgDocument.FromSvg<SvgDocument>(rawSvg);
+            var rect = RectangleF.Create(x, y, wh, wh);
+
+            // Act
+            var result = svg.HitTest<SvgVisualElement>(rect, selectionType);
+
+            // Assert
+            if (!expectsHitSuccessful)
+                result.Should().BeEmpty();
+            else
+                result.Should().HaveCount(1);
+        }
+
+        [TestCase("outside tap", SelectionType.Intersect, 75, 75, 10, false)]
+        [TestCase("line x tap", SelectionType.Intersect, 0, 100, 10, true)]
+        [TestCase("line end tap", SelectionType.Intersect, -5, 200, 10, true)]
+        public void OnZoomedPannedCanvas_VerticalLine(string ___, SelectionType selectionType, float x, float y, float wh, bool expectsHitSuccessful)
+        {
+            // Arrange
+            var rawSvg = $@"
+<svg height=""500"" width=""500"" id=""karo"">
+  <line x1=""0"" y1=""0"" x2=""0"" y2=""200"" style=""stroke:purple;stroke-width:1"" />
+</svg>";
+            var svg = SvgDocument.FromSvg<SvgDocument>(rawSvg);
+            var rect = RectangleF.Create(x, y, wh, wh);
+            
+            // simulate user zooming and panning
+            var canvasMatrix = Matrix.Create();
+            canvasMatrix.Translate(100, 200);
+            canvasMatrix.Scale(3, 3);
+            // and selecting some rectangle on panned&zoomed canvas
+            rect = canvasMatrix.TransformRectangle(rect);
+
+            // Act
+            var result = svg.HitTest<SvgVisualElement>(rect, selectionType, matrix:canvasMatrix);
+
+            // Assert
+            if (!expectsHitSuccessful)
+                result.Should().BeEmpty();
+            else
+                result.Should().HaveCount(1);
+        }
+
+        [TestCase("outside tap", SelectionType.Intersect, 75, 75, 10, false)]
+        [TestCase("~x start tap", SelectionType.Intersect, -5, 0, 10, true)]
+        [TestCase("~y start tap", SelectionType.Intersect, 0, -5, 10, true)]
+        [TestCase("center tap", SelectionType.Intersect, 100, 0, 10, true)]
+        public void HorizontalLine(string ___, SelectionType selectionType, float x, float y, float wh, bool expectsHitSuccessful)
+        {
+            // Arrange
+            var rawSvg = $@"
+<svg height=""500"" width=""500"" id=""karo"">
+  <line x1=""0"" y1=""0"" x2=""200"" y2=""0"" style=""stroke:purple;stroke-width:1"" />
+</svg>";
+            var svg = SvgDocument.FromSvg<SvgDocument>(rawSvg);
+            var rect = RectangleF.Create(x, y, wh, wh);
+
+            // Act
+            var result = svg.HitTest<SvgVisualElement>(rect, selectionType);
+
+            // Assert
+            if (!expectsHitSuccessful)
+                result.Should().BeEmpty();
+            else
+                result.Should().HaveCount(1);
+        }
+
+        [TestCase("outside tap", SelectionType.Intersect, 75, 75, 10, false)]
+        [TestCase("~x start tap", SelectionType.Intersect, -5, 0, 10, true)]
+        [TestCase("~y start tap", SelectionType.Intersect, 0, -5, 10, true)]
+        [TestCase("center tap", SelectionType.Intersect, 100, 0, 10, true)]
+        public void OnZoomedPannedCanvas_HorizontalLine(string ___, SelectionType selectionType, float x, float y, float wh, bool expectsHitSuccessful)
+        {
+            // Arrange
+            var rawSvg = $@"
+<svg height=""500"" width=""500"" id=""karo"">
+  <line x1=""0"" y1=""0"" x2=""200"" y2=""0"" style=""stroke:purple;stroke-width:1"" />
+</svg>";
+            var svg = SvgDocument.FromSvg<SvgDocument>(rawSvg);
+            var rect = RectangleF.Create(x, y, wh, wh);
+
+            // simulate user zooming and panning
+            var canvasMatrix = Matrix.Create();
+            canvasMatrix.Translate(100, 200);
+            canvasMatrix.Scale(3, 3);
+            // and selecting some rectangle on panned&zoomed canvas
+            rect = canvasMatrix.TransformRectangle(rect);
+
+            // Act
+            var result = svg.HitTest<SvgVisualElement>(rect, selectionType, matrix:canvasMatrix);
+
+            // Assert
+            if (!expectsHitSuccessful)
+                result.Should().BeEmpty();
+            else
+                result.Should().HaveCount(1);
+        }
+    }
+}

--- a/Svg.Tests.Win/SvgHitTests_PolyLine.cs
+++ b/Svg.Tests.Win/SvgHitTests_PolyLine.cs
@@ -1,0 +1,92 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using Svg.Interfaces;
+
+namespace Svg.Tests.Win
+{
+    /// <summary>
+    /// Hint: Try online in editor of w3schools
+    /// https://www.w3schools.com/graphics/tryit.asp?filename=trysvg_polyline
+    /// </summary>
+    [TestFixture]
+    public class SvgHitTests_PolyLine
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            SvgPlatform.Init();
+        }
+
+        [TestCase("outside tap w/o fill", SelectionType.Intersect, 75, 75, 10, "none", false)]
+        [TestCase("outside tap w fill", SelectionType.Intersect, 200, 10, 10, "lime", false)]
+        [TestCase("center tap w/o fill", SelectionType.Intersect, 100, 200, 10, "none", false)]
+        [TestCase("center tap w fill", SelectionType.Intersect, 100, 200, 10, "lime", true)]
+        [TestCase("first line tap w/o fill", SelectionType.Intersect, 150, 150, 10, "none", true)]
+        [TestCase("~first line tap w/o fill", SelectionType.Intersect, 155, 150, 10, "none", true)]
+        [TestCase("second line tap w/o fill", SelectionType.Intersect, 145, 250, 10, "none", true)]
+        [TestCase("~second line tap w/o fill", SelectionType.Intersect, 140, 250, 10, "none", true)]
+        [TestCase("third line tap w/o fill", SelectionType.Intersect, 45, 250, 10, "none", true)]
+        [TestCase("~third line tap w/o fill", SelectionType.Intersect, 50, 250, 10, "none", true)]
+        [TestCase("NOT EXISTNG fourth line tap w/o fill", SelectionType.Intersect, 45, 150, 10, "none", false)]
+        [TestCase("NOT EXISTNG ~fourth line tap w/o fill", SelectionType.Intersect, 40, 150, 10, "none", false)]
+        public void IsHit(string ___, SelectionType selectionType, float x, float y, float wh, string fill, bool expectsHitSuccessful)
+        {
+            // Arrange
+            var rawSvg = $@"
+<svg height=""500"" width=""500"" id=""karo"">
+  <polyline points=""100,100 200,200 100,300 0,200"" style=""fill:{fill};stroke:purple;stroke-width:1"" />
+</svg>";
+            var svg = SvgDocument.FromSvg<SvgDocument>(rawSvg);
+            var rect = RectangleF.Create(x, y, wh, wh);
+
+            // Act
+            var result = svg.HitTest<SvgVisualElement>(rect, selectionType);
+
+            // Assert
+            if (!expectsHitSuccessful)
+                result.Should().BeEmpty();
+            else
+                result.Should().HaveCount(1);
+        }
+    
+
+        [TestCase("outside tap w/o fill", SelectionType.Intersect, 75, 75, 10, "none", false)]
+        [TestCase("outside tap w fill", SelectionType.Intersect, 200, 10, 10, "lime", false)]
+        [TestCase("center tap w/o fill", SelectionType.Intersect, 100, 200, 10, "none", false)]
+        [TestCase("center tap w fill", SelectionType.Intersect, 100, 200, 10, "lime", true)]
+        [TestCase("first line tap w/o fill", SelectionType.Intersect, 150, 150, 10, "none", true)]
+        [TestCase("~first line tap w/o fill", SelectionType.Intersect, 155, 150, 10, "none", true)]
+        [TestCase("second line tap w/o fill", SelectionType.Intersect, 145, 250, 10, "none", true)]
+        [TestCase("~second line tap w/o fill", SelectionType.Intersect, 140, 250, 10, "none", true)]
+        [TestCase("third line tap w/o fill", SelectionType.Intersect, 45, 250, 10, "none", true)]
+        [TestCase("~third line tap w/o fill", SelectionType.Intersect, 50, 250, 10, "none", true)]
+        [TestCase("NOT EXISTNG fourth line tap w/o fill", SelectionType.Intersect, 45, 150, 10, "none", false)]
+        [TestCase("NOT EXISTNG ~fourth line tap w/o fill", SelectionType.Intersect, 40, 150, 10, "none", false)]
+        public void OnZoomedPannedCanvas_IsHit(string ___, SelectionType selectionType, float x, float y, float wh, string fill, bool expectsHitSuccessful)
+        {
+            // Arrange
+            var rawSvg = $@"
+<svg height=""500"" width=""500"" id=""karo"">
+  <polyline points=""100,100 200,200 100,300 0,200"" style=""fill:{fill};stroke:purple;stroke-width:1"" />
+</svg>";
+            var svg = SvgDocument.FromSvg<SvgDocument>(rawSvg);
+            var rect = RectangleF.Create(x, y, wh, wh);
+
+            // simulate user zooming and panning
+            var canvasMatrix = Matrix.Create();
+            canvasMatrix.Translate(100, 200);
+            canvasMatrix.Scale(3, 3);
+            // and selecting some rectangle on panned&zoomed canvas
+            rect = canvasMatrix.TransformRectangle(rect);
+
+            // Act
+            var result = svg.HitTest<SvgVisualElement>(rect, selectionType, matrix:canvasMatrix);
+
+            // Assert
+            if (!expectsHitSuccessful)
+                result.Should().BeEmpty();
+            else
+                result.Should().HaveCount(1);
+        }
+    }
+}

--- a/Svg.Tests.Win/SvgHitTests_Polygon.cs
+++ b/Svg.Tests.Win/SvgHitTests_Polygon.cs
@@ -1,0 +1,91 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using Svg.Interfaces;
+
+namespace Svg.Tests.Win
+{
+    /// <summary>
+    /// Hint: Try online in editor of w3schools
+    /// https://www.w3schools.com/graphics/tryit.asp?filename=trysvg_polygon2
+    /// </summary>
+    [TestFixture]
+    public class SvgHitTests_Polygon
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            SvgPlatform.Init();
+        }
+
+        [TestCase("outside tap w/o fill", SelectionType.Intersect, 75, 75, 10, "none", false)]
+        [TestCase("outside tap w fill", SelectionType.Intersect, 200, 10, 10, "lime", false)]
+        [TestCase("center tap w/o fill", SelectionType.Intersect, 100,200,10,"none", false)]
+        [TestCase("center tap w fill", SelectionType.Intersect, 100, 200, 10, "lime", true)]
+        [TestCase("first line tap w/o fill", SelectionType.Intersect, 150, 150, 10, "none", true)]
+        [TestCase("~first line tap w/o fill", SelectionType.Intersect, 155, 150, 10, "none", true)]
+        [TestCase("second line tap w/o fill", SelectionType.Intersect, 145, 250, 10, "none", true)]
+        [TestCase("~second line tap w/o fill", SelectionType.Intersect, 140, 250, 10, "none", true)]
+        [TestCase("third line tap w/o fill", SelectionType.Intersect, 45, 250, 10, "none", true)]
+        [TestCase("~third line tap w/o fill", SelectionType.Intersect, 50, 250, 10, "none", true)]
+        [TestCase("fourth line tap w/o fill", SelectionType.Intersect, 45, 150, 10, "none", true)]
+        [TestCase("~fourth line tap w/o fill", SelectionType.Intersect, 40, 150, 10, "none", true)]
+        public void IsHit(string ___, SelectionType selectionType, float x, float y, float wh, string fill, bool expectsHitSuccessful)
+        {
+            // Arrange
+            var rawSvg = $@"
+<svg height=""500"" width=""500"" id=""karo"">
+  <polygon points=""100,100 200,200 100,300 0,200"" style=""fill:{fill};stroke:purple;stroke-width:1"" />
+</svg>";
+            var svg = SvgDocument.FromSvg<SvgDocument>(rawSvg);
+            var rect = RectangleF.Create(x, y, wh, wh);
+
+            // Act
+            var result = svg.HitTest<SvgVisualElement>(rect, selectionType);
+
+            // Assert
+            if (!expectsHitSuccessful)
+                result.Should().BeEmpty();
+            else
+                result.Should().HaveCount(1);
+        }
+
+        [TestCase("outside tap w/o fill", SelectionType.Intersect, 75, 75, 10, "none", false)]
+        [TestCase("outside tap w fill", SelectionType.Intersect, 200, 10, 10, "lime", false)]
+        [TestCase("center tap w/o fill", SelectionType.Intersect, 100,200,10,"none", false)]
+        [TestCase("center tap w fill", SelectionType.Intersect, 100, 200, 10, "lime", true)]
+        [TestCase("first line tap w/o fill", SelectionType.Intersect, 150, 150, 10, "none", true)]
+        [TestCase("~first line tap w/o fill", SelectionType.Intersect, 155, 150, 10, "none", true)]
+        [TestCase("second line tap w/o fill", SelectionType.Intersect, 145, 250, 10, "none", true)]
+        [TestCase("~second line tap w/o fill", SelectionType.Intersect, 140, 250, 10, "none", true)]
+        [TestCase("third line tap w/o fill", SelectionType.Intersect, 45, 250, 10, "none", true)]
+        [TestCase("~third line tap w/o fill", SelectionType.Intersect, 50, 250, 10, "none", true)]
+        [TestCase("fourth line tap w/o fill", SelectionType.Intersect, 45, 150, 10, "none", true)]
+        [TestCase("~fourth line tap w/o fill", SelectionType.Intersect, 40, 150, 10, "none", true)]
+        public void OnPannedZoomedCanvas_IsHit(string ___, SelectionType selectionType, float x, float y, float wh, string fill, bool expectsHitSuccessful)
+        {
+            // Arrange
+            var rawSvg = $@"
+<svg height=""500"" width=""500"" id=""karo"">
+  <polygon points=""100,100 200,200 100,300 0,200"" style=""fill:{fill};stroke:purple;stroke-width:1"" />
+</svg>";
+            var svg = SvgDocument.FromSvg<SvgDocument>(rawSvg);
+            var rect = RectangleF.Create(x, y, wh, wh);
+
+            // simulate user zooming and panning
+            var canvasMatrix = Matrix.Create();
+            canvasMatrix.Translate(100, 200);
+            canvasMatrix.Scale(3, 3);
+            // and selecting some rectangle on panned&zoomed canvas
+            rect = canvasMatrix.TransformRectangle(rect);
+
+            // Act
+            var result = svg.HitTest<SvgVisualElement>(rect, selectionType, matrix:canvasMatrix);
+
+            // Assert
+            if (!expectsHitSuccessful)
+                result.Should().BeEmpty();
+            else
+                result.Should().HaveCount(1);
+        }
+    }
+}

--- a/Svg.Tests.Win/SvgHitTests_Rectangle.cs
+++ b/Svg.Tests.Win/SvgHitTests_Rectangle.cs
@@ -1,0 +1,91 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using Svg.Interfaces;
+
+namespace Svg.Tests.Win
+{
+    /// <summary>
+    /// Hint: Try online in editor of w3schools
+    /// https://www.w3schools.com/graphics/tryit.asp?filename=trysvg_rect
+    /// </summary>
+    [TestFixture]
+    public class SvgHitTests_Rectangle
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            SvgPlatform.Init();
+        }
+
+        [TestCase("outside tap w/o fill", SelectionType.Intersect, 75, 75, 10, "none", false)]
+        [TestCase("outside tap w fill", SelectionType.Intersect, 200, 10, 10, "lime", false)]
+        [TestCase("center tap w/o fill", SelectionType.Intersect, 150, 150, 10, "none", false)]
+        [TestCase("center tap w fill", SelectionType.Intersect, 150, 150, 10, "lime", true)]
+        [TestCase("top line tap w/o fill", SelectionType.Intersect, 150, 95, 10, "none", true)]
+        [TestCase("~top line tap w/o fill", SelectionType.Intersect, 155, 100, 10, "none", true)]
+        [TestCase("right line tap w/o fill", SelectionType.Intersect, 195, 150, 10, "none", true)]
+        [TestCase("~right line tap w/o fill", SelectionType.Intersect, 199, 150, 10, "none", true)]
+        [TestCase("lower line tap w/o fill", SelectionType.Intersect, 150, 195, 10, "none", true)]
+        [TestCase("~lower line tap w/o fill", SelectionType.Intersect, 150, 199, 10, "none", true)]
+        [TestCase("left line tap w/o fill", SelectionType.Intersect, 95, 150, 10, "none", true)]
+        [TestCase("~left line tap w/o fill", SelectionType.Intersect, 100, 150, 10, "none", true)]
+        public void IsHit(string ___, SelectionType selectionType, float x, float y, float wh, string fill, bool expectsHitSuccessful)
+        {
+            // Arrange
+            var rawSvg = $@"
+<svg height=""500"" width=""500"" id=""karo"">
+  <rect x=""100"" y=""100"" width=""100"" height=""100"" style=""fill:{fill};stroke:purple;stroke-width:1"" />
+</svg>";
+            var svg = SvgDocument.FromSvg<SvgDocument>(rawSvg);
+            var rect = RectangleF.Create(x, y, wh, wh);
+
+            // Act
+            var result = svg.HitTest<SvgVisualElement>(rect, selectionType);
+
+            // Assert
+            if (!expectsHitSuccessful)
+                result.Should().BeEmpty();
+            else
+                result.Should().HaveCount(1);
+        }
+    
+        [TestCase("outside tap w/o fill", SelectionType.Intersect, 75, 75, 10, "none", false)]
+        [TestCase("outside tap w fill", SelectionType.Intersect, 200, 10, 10, "lime", false)]
+        [TestCase("center tap w/o fill", SelectionType.Intersect, 150, 150, 10, "none", false)]
+        [TestCase("center tap w fill", SelectionType.Intersect, 150, 150, 10, "lime", true)]
+        [TestCase("top line tap w/o fill", SelectionType.Intersect, 150, 95, 10, "none", true)]
+        [TestCase("~top line tap w/o fill", SelectionType.Intersect, 155, 100, 10, "none", true)]
+        [TestCase("right line tap w/o fill", SelectionType.Intersect, 195, 150, 10, "none", true)]
+        [TestCase("~right line tap w/o fill", SelectionType.Intersect, 199, 150, 10, "none", true)]
+        [TestCase("lower line tap w/o fill", SelectionType.Intersect, 150, 195, 10, "none", true)]
+        [TestCase("~lower line tap w/o fill", SelectionType.Intersect, 150, 199, 10, "none", true)]
+        [TestCase("left line tap w/o fill", SelectionType.Intersect, 95, 150, 10, "none", true)]
+        [TestCase("~left line tap w/o fill", SelectionType.Intersect, 100, 150, 10, "none", true)]
+        public void OnZoomedPannedCanvas_IsHit(string ___, SelectionType selectionType, float x, float y, float wh, string fill, bool expectsHitSuccessful)
+        {
+            // Arrange
+            var rawSvg = $@"
+<svg height=""500"" width=""500"" id=""karo"">
+  <rect x=""100"" y=""100"" width=""100"" height=""100"" style=""fill:{fill};stroke:purple;stroke-width:1"" />
+</svg>";
+            var svg = SvgDocument.FromSvg<SvgDocument>(rawSvg);
+            var rect = RectangleF.Create(x, y, wh, wh);
+
+            // simulate user zooming and panning
+            var canvasMatrix = Matrix.Create();
+            canvasMatrix.Translate(100, 200);
+            canvasMatrix.Scale(3, 3);
+            // and selecting some rectangle on panned&zoomed canvas
+            rect = canvasMatrix.TransformRectangle(rect);
+
+            // Act
+            var result = svg.HitTest<SvgVisualElement>(rect, selectionType, matrix:canvasMatrix);
+
+            // Assert
+            if (!expectsHitSuccessful)
+                result.Should().BeEmpty();
+            else
+                result.Should().HaveCount(1);
+        }
+    }
+}

--- a/Svg/Basic Shapes/SvgLine.cs
+++ b/Svg/Basic Shapes/SvgLine.cs
@@ -163,6 +163,14 @@ namespace Svg
             return result;
         }
 
+        protected internal override bool IntersectsWith(RectangleF rectangle, Matrix transform, int maxRecursion)
+        {
+            var start = PointF.Create(this.StartX, this.StartY);
+            var end = PointF.Create(this.EndX, this.EndY);
+            
+            return (start,end).IsIntersectingWithLine(transform, rectangle);
+        }
+
         public override RectangleF Bounds
         {
             get

--- a/Svg/Basic Shapes/SvgPolygon.cs
+++ b/Svg/Basic Shapes/SvgPolygon.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Svg.Interfaces;
 using Svg.Pathing;
 
@@ -11,7 +13,7 @@ namespace Svg
     public class SvgPolygon : SvgVisualElement
     {
         private GraphicsPath _path;
-        
+
         /// <summary>
         /// The points that make up the SvgPolygon
         /// </summary>
@@ -19,7 +21,11 @@ namespace Svg
         public SvgPointCollection Points
         {
             get { return this.Attributes["points"] as SvgPointCollection; }
-            set { this.Attributes["points"] = value; this.IsPathDirty = true; }
+            set
+            {
+                this.Attributes["points"] = value;
+                this.IsPathDirty = true;
+            }
         }
 
         /// <summary>
@@ -76,7 +82,8 @@ namespace Svg
                         //first line
                         if (_path.PointCount == 0)
                         {
-                            _path.AddLine(SvgUnit.GetDevicePoint(points[i - 2], points[i - 1], renderer, this), endPoint);
+                            _path.AddLine(SvgUnit.GetDevicePoint(points[i - 2], points[i - 1], renderer, this),
+                                endPoint);
                         }
                         else
                         {
@@ -92,6 +99,7 @@ namespace Svg
                 this._path.CloseFigure();
                 this.IsPathDirty = false;
             }
+
             return this._path;
         }
 
@@ -114,13 +122,15 @@ namespace Svg
             {
                 SvgMarker marker = this.OwnerDocument.GetElementById<SvgMarker>(this.MarkerMid.ToString());
                 for (int i = 1; i <= path.PathPoints.Length - 2; i++)
-                    marker.RenderMarker(renderer, this, path.PathPoints[i], path.PathPoints[i - 1], path.PathPoints[i], path.PathPoints[i + 1]);
+                    marker.RenderMarker(renderer, this, path.PathPoints[i], path.PathPoints[i - 1], path.PathPoints[i],
+                        path.PathPoints[i + 1]);
             }
 
             if (this.MarkerEnd != null)
             {
                 SvgMarker marker = this.OwnerDocument.GetElementById<SvgMarker>(this.MarkerEnd.ToString());
-                marker.RenderMarker(renderer, this, path.PathPoints[path.PathPoints.Length - 1], path.PathPoints[path.PathPoints.Length - 2], path.PathPoints[path.PathPoints.Length - 1]);
+                marker.RenderMarker(renderer, this, path.PathPoints[path.PathPoints.Length - 1],
+                    path.PathPoints[path.PathPoints.Length - 2], path.PathPoints[path.PathPoints.Length - 1]);
             }
 
             return result;
@@ -128,25 +138,45 @@ namespace Svg
 
         public override RectangleF Bounds
         {
-            get
-            {
-                return this.Path(null).GetBounds();
-            }
+            get { return this.Path(null).GetBounds(); }
         }
 
+        public override SvgElement DeepCopy()
+        {
+            return DeepCopy<SvgPolygon>();
+        }
 
-		public override SvgElement DeepCopy()
-		{
-			return DeepCopy<SvgPolygon>();
-		}
+        public override SvgElement DeepCopy<T>()
+        {
+            var newObj = base.DeepCopy<T>() as SvgPolygon;
+            newObj.Points = new SvgPointCollection();
+            foreach (var pt in this.Points)
+                newObj.Points.Add(pt);
+            return newObj;
+        }
 
-		public override SvgElement DeepCopy<T>()
-		{
-			var newObj = base.DeepCopy<T>() as SvgPolygon;
-			newObj.Points = new SvgPointCollection();
-			foreach (var pt in this.Points)
-				newObj.Points.Add(pt);
-			return newObj;
-		}
+        protected internal override bool IntersectsWith(RectangleF rectangle, Matrix transform, int maxRecursion)
+        {
+            if (this.HasFill())
+                return true;
+
+            var units = Points.ToList();
+
+            var lineSegments = new List<(PointF from, PointF to)>();
+            for (var i = 0; i < units.Count - 3; i += 2)
+            {
+                lineSegments.Add((
+                    PointF.Create(units[i].Value, units[i + 1].Value),
+                    PointF.Create(units[i + 2].Value, units[i + 3].Value)
+                ));
+            }
+            // finally, add last line segment that connects the last with the first point of the polygon...
+            lineSegments.Add((
+                PointF.Create(units[units.Count-2].Value, units[units.Count-1].Value),
+                PointF.Create(units[0].Value, units[1].Value))
+                );
+
+            return lineSegments.IsIntersectingWithLine(transform, rectangle);
+        }
     }
 }

--- a/Svg/Basic Shapes/SvgPolyline.cs
+++ b/Svg/Basic Shapes/SvgPolyline.cs
@@ -1,6 +1,7 @@
 using System;
-
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using Svg.Interfaces;
 
 namespace Svg
@@ -106,6 +107,27 @@ namespace Svg
             }
 
             return result;
+        }
+
+        protected internal override bool IntersectsWith(RectangleF rectangle, Matrix transform, int maxRecursion)
+        {
+            if (this.HasFill())
+                return true;
+
+            var units = Points.ToList();
+
+            var lineSegments = new List<(PointF from, PointF to)>();
+            for (var i = 0; i < units.Count - 3; i += 2)
+            {
+                lineSegments.Add((
+                    PointF.Create(units[i].Value, units[i + 1].Value),
+                    PointF.Create(units[i + 2].Value, units[i + 3].Value)
+                ));
+            }
+            // does not add last line which connects last point to first point as this would be a polygon
+            // see: https://www.w3schools.com/graphics/svg_polyline.asp
+
+            return lineSegments.IsIntersectingWithLine(transform, rectangle);
         }
     }
 }

--- a/Svg/Basic Shapes/SvgRectangle.cs
+++ b/Svg/Basic Shapes/SvgRectangle.cs
@@ -1,5 +1,5 @@
 using System;
-
+using System.Collections.Generic;
 using Svg.Interfaces;
 
 namespace Svg
@@ -281,8 +281,26 @@ namespace Svg
             }
         }
 
+        protected internal override bool IntersectsWith(RectangleF rectangle, Matrix transform, int maxRecursion)
+        {
+            if (this.HasFill())
+                return true;
+            
+            var leftTop = PointF.Create(this.X, this.Y);
+            var rightTop = PointF.Create(this.X + this.Width, this.Y);
+            var rightBottom = PointF.Create(this.X + this.Width, this.Y + this.Height);
+            var leftBottom = PointF.Create(this.X, this.Y + this.Height);
 
-		public override SvgElement DeepCopy()
+            var lineSegments = new List<(PointF from, PointF to)>();
+            lineSegments.Add((leftTop.Clone(), rightTop.Clone()));
+            lineSegments.Add((rightTop.Clone(),rightBottom.Clone()));
+            lineSegments.Add((rightBottom.Clone(),leftBottom.Clone()));
+            lineSegments.Add((leftBottom.Clone(), leftTop.Clone()));
+
+            return lineSegments.IsIntersectingWithLine(transform, rectangle);
+        }
+
+        public override SvgElement DeepCopy()
 		{
 			return DeepCopy<SvgRectangle>();
 		}

--- a/Svg/Basic Shapes/SvgVisualElement.cs
+++ b/Svg/Basic Shapes/SvgVisualElement.cs
@@ -7,12 +7,6 @@ using Svg.Transforms;
 
 namespace Svg
 {
-    public enum SelectionType
-    {
-        Intersect,
-        Contain
-    }
-
     /// <summary>
     /// The class that all SVG elements should derive from when they are to be rendered.
     /// </summary>
@@ -91,11 +85,11 @@ namespace Svg
             
             if (Renderable)
             {
-                return GetTransformedElementPoints(transform);
+                return this.GetTransformedElementPoints(transform);
             }
             else
             {
-                return GetTransformedChildPoints(transform);
+                return this.GetTransformedChildPoints(transform);
             }
         }
 
@@ -105,108 +99,30 @@ namespace Svg
             
             return RectangleF.FromPoints(pts);
         }
-
-        public IEnumerable<TElement> HitTest<TElement>(RectangleF rectangle, SelectionType selectionType = SelectionType.Intersect,
-            Matrix transform = null, int maxRecursion = int.MaxValue) where TElement : SvgVisualElement
+        
+        [Obsolete("Use the overload with selectionMode")]
+        public IEnumerable<TElement> HitTest<TElement>(RectangleF rectangle,
+            SelectionType selectionType = SelectionType.Intersect,
+            Matrix transform = null, 
+            int maxRecursion = int.MaxValue) where TElement : SvgVisualElement
         {
-            return HitTestInternal<TElement>(rectangle, selectionType, transform ?? Matrix.Create(), maxRecursion);
+            return this.HitTest<TElement>(rectangle, selectionType, HitTestResultMode.ReturnAllMatchingDescendants, transform ?? Matrix.Create(), maxRecursion);
         }
-
-        private IEnumerable<TElement> HitTestInternal<TElement>(RectangleF rectangle, SelectionType selectionType,
-            Matrix transform, int maxRecursion) where TElement : SvgVisualElement
+        
+        /// <summary>
+        /// This method gives a specific shape the chance to add additional hit testing logic.
+        /// In case the elements bounding box is found during hit-testing, this method will be called, so that the element can still refuse to be hit
+        /// This is useful, if e.g. a polygon without fill color should only be considered hit, if its border/line was hit
+        /// </summary>
+        /// <param name="rectangle"></param>
+        /// <param name="transform"></param>
+        /// <param name="maxRecursion"></param>
+        /// <returns></returns>
+        protected internal virtual bool IntersectsWith(RectangleF rectangle, Matrix transform, int maxRecursion)
         {
-            if (transform == null)
-                transform = Matrix.Create();
-            else
-                transform = transform.Clone();
-
-            if (Renderable)
-            {
-                var pts = GetTransformedElementPoints(transform);
-                var box = RectangleF.FromPoints(pts);
-
-                // if this element fits the type filter, check if it fits the hittest rectangle
-                if (this is TElement)
-                {
-                    if ((selectionType == SelectionType.Intersect) && rectangle.IntersectsWith(box))
-                        yield return (TElement)this;
-                    else if ((selectionType == SelectionType.Contain) && rectangle.Contains(box))
-                        yield return (TElement)this;
-                }
-            }
-            else
-            {
-                // recurse the hittest to the inner levels
-                var recurs = maxRecursion - 1;
-                if (recurs > 0)
-                {
-                    var t2 = transform.Clone();
-                    foreach (SvgTransform transformation in this.Transforms)
-                    {
-                        transformation.ApplyTo(t2);
-                    }
-
-                    // reverse children because of z-index
-                    foreach (var hit in this.Children.Reverse().OfType<SvgVisualElement>()
-                            .SelectMany(child => child.HitTestInternal<TElement>(rectangle, selectionType, t2, recurs)))
-                    {
-                        yield return hit;
-                    }
-                }
-
-                // if this element fits the type filter, check if it fits the hittest rectangle
-                if (this is TElement)
-                {
-                    var points = GetTransformedChildPoints(transform);
-                    var box = RectangleF.FromPoints(points);
-
-                    if ((selectionType == SelectionType.Intersect) && rectangle.IntersectsWith(box))
-                        yield return (TElement) this;
-                    else if ((selectionType == SelectionType.Contain) && rectangle.Contains(box))
-                        yield return (TElement) this;
-                }
-            }
+            return true;
         }
-
-        private PointF[] GetTransformedElementPoints(Matrix transform)
-        {
-            var b = Bounds;
-            var p1 = PointF.Create(b.Left, b.Top);
-            var p2 = PointF.Create(b.Right, b.Top);
-            var p3 = PointF.Create(b.Right, b.Bottom);
-            var p4 = PointF.Create(b.Left, b.Bottom);
-
-            var pts = new[] {p1, p2, p3, p4};
-
-            foreach (SvgTransform transformation in this.Transforms)
-            {
-                transformation.ApplyTo(transform);
-            }
-
-            transform.TransformPoints(pts);
-            return pts.Select(p => p.Clone()).ToArray();
-        }
-
-        private PointF[] GetTransformedChildPoints(Matrix transform)
-        {
-            var pts = new List<PointF>();
-
-            foreach (SvgTransform transformation in this.Transforms)
-            {
-                transformation.ApplyTo(transform);
-            }
-
-            foreach (var c in this.Children)
-            {
-                if (c is SvgVisualElement)
-                {
-                    var childBounds = ((SvgVisualElement) c).GetTransformedPoints(transform);
-                    pts.AddRange(childBounds);
-                }
-            }
-            return pts.Select(p => p.Clone()).ToArray();
-        }
-
+        
         /// <summary>
         /// Gets the associated <see cref="SvgClipPath"/> if one has been specified.
         /// </summary>
@@ -264,7 +180,7 @@ namespace Svg
             this._requiresSmoothRendering = false;
         }
 
-        protected virtual bool Renderable { get { return true; } }
+        protected internal virtual bool Renderable { get { return true; } }
 
         /// <summary>
         /// Renders the <see cref="SvgElement"/> and contents to the specified <see cref="Graphics"/> object.
@@ -353,7 +269,7 @@ namespace Svg
                 fill = (SvgPaintServer)fillTemp;
             }
 
-            if (fill != null)
+            if (this.HasFill())
             {
                 /*using (*/
                 //var brush = GetFillBrush(renderer);/*)*/
@@ -383,7 +299,7 @@ namespace Svg
                 stroke = (SvgPaintServer)strokeTemp;
             }
 
-            if (stroke != null && stroke != SvgColourServer.None)
+            if (this.HasStroke())
             {
                 float strokeWidth = this.StrokeWidth.ToDeviceValue(renderer, UnitRenderingType.Other, this);
                 //using (var brush = GetStrokeBrush(renderer))

--- a/Svg/Document Structure/SvgGroup.cs
+++ b/Svg/Document Structure/SvgGroup.cs
@@ -52,7 +52,7 @@ namespace Svg
             }
         }
 
-        protected override bool Renderable { get { return false; } }
+        protected internal override bool Renderable { get { return false; } }
                 
         public override SvgElement DeepCopy()
         {

--- a/Svg/Document Structure/SvgSymbol.cs
+++ b/Svg/Document Structure/SvgSymbol.cs
@@ -79,7 +79,7 @@ namespace Svg.Document_Structure
             }
         }
 
-        protected override bool Renderable { get { return false; } }
+        protected internal override bool Renderable { get { return false; } }
 
         /// <summary>
         /// Applies the required transforms to <see cref="ISvgRenderer"/>.

--- a/Svg/Document Structure/SvgUse.cs
+++ b/Svg/Document Structure/SvgUse.cs
@@ -68,7 +68,7 @@ namespace Svg
             }
         }
 
-        protected override bool Renderable { get { return false; } }
+        protected internal override bool Renderable { get { return false; } }
 
         protected override void Render(ISvgRenderer renderer)
         {

--- a/Svg/Extensibility/SvgForeignObject.cs
+++ b/Svg/Extensibility/SvgForeignObject.cs
@@ -56,7 +56,7 @@ namespace Svg
             }
         }
 
-        protected override bool Renderable { get { return false; } }
+        protected internal override bool Renderable { get { return false; } }
 
         ///// <summary>
         ///// Renders the <see cref="SvgElement"/> and contents to the specified <see cref="Graphics"/> object.

--- a/Svg/Interfaces/RectangleF.cs
+++ b/Svg/Interfaces/RectangleF.cs
@@ -591,8 +591,9 @@ namespace Svg.Interfaces
 
         public override string ToString()
         {
-            return String.Format("{{X={0},Y={1},Width={2},Height={3}}}",
-                         x, y, width, height);
+            return $"<rect x=\"{x}\" y=\"{y}\" width=\"{width}\" height=\"{height}\" style=\"fill:black\" />";
+            //return String.Format("{{X={0},Y={1},Width={2},Height={3}}}",
+            //             x, y, width, height);
         }
 
         public RectangleF UnionAndCopy(RectangleF childBounds)

--- a/Svg/Painting/SvgMarker.cs
+++ b/Svg/Painting/SvgMarker.cs
@@ -292,6 +292,6 @@ namespace Svg
             return true;
         }
 
-        protected override bool Renderable => false;
+        protected internal override bool Renderable => false;
     }
 }

--- a/Svg/Paths/SvgPath.cs
+++ b/Svg/Paths/SvgPath.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Svg.Interfaces;
 using Svg.Pathing;
 using Svg.Transforms;
@@ -157,8 +159,18 @@ namespace Svg
                 
             return result;
 		}
+        
+        protected internal override bool IntersectsWith(RectangleF rectangle, Matrix transform, int maxRecursion)
+        {
+            if (this.HasFill())
+                return true;
 
-		public override SvgElement DeepCopy()
+            var lineSegments = this.PathData.Select(seg => (seg.Start, seg.End)).ToList();
+
+            return lineSegments.IsIntersectingWithLine(transform, rectangle);
+        }
+
+        public override SvgElement DeepCopy()
 		{
 			return DeepCopy<SvgPath>();
 		}

--- a/Svg/Platform/Shared/FileSystem.cs
+++ b/Svg/Platform/Shared/FileSystem.cs
@@ -31,7 +31,7 @@ namespace Svg
             return path;
         }
 
-        public string GetDefaultStoragePath()
+        public virtual string GetDefaultStoragePath()
         {
 #if WINDOWS_UWP
             return Windows.Storage.ApplicationData.Current.LocalFolder.Path;

--- a/Svg/Platform/SkiaRectangleF.cs
+++ b/Svg/Platform/SkiaRectangleF.cs
@@ -26,7 +26,8 @@ namespace Svg.Platform
 
         public override string ToString()
         {
-            return $"x:{X} y:{Y} width:{Width} height:{Height}";
+            return $"<rect x=\"{X}\" y=\"{Y}\" width=\"{Width}\" height=\"{Height}\" style=\"fill:black\" />";
+            //return $"x:{X} y:{Y} width:{Width} height:{Height}";
         }
     }
 }

--- a/Svg/Svg.csproj
+++ b/Svg/Svg.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;MonoAndroid81;Xamarin.iOS10;uap10.0.18362;net462</TargetFrameworks>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-    <Version>2.4.3.1</Version>
+    <Version>2.4.3.3</Version>
     <Authors>gentledpp,bruzkovsky</Authors>
     <Company>Opti-Q GmbH</Company>
     <PackageReleaseNotes>netstandard multiplatform</PackageReleaseNotes>

--- a/Svg/SvgExtentions.cs
+++ b/Svg/SvgExtentions.cs
@@ -1,10 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
-
 using System.IO;
-using System.Xml;
-using System.Threading;
 using System.Globalization;
 using Svg.Interfaces;
 using Svg.Interfaces.Xml;
@@ -22,6 +18,11 @@ namespace Svg
             r.Y = bounds.Y;
             r.Width = bounds.Width;
             r.Height = bounds.Height;
+        }
+
+        public static PointF GetCenterPoint(this RectangleF r)
+        {
+            return PointF.Create(r.X + (r.Width / 2f), r.Y + (r.Height / 2f));
         }
 
         public static RectangleF GetRectangle(this SvgRectangle r)
@@ -140,5 +141,21 @@ namespace Svg
                     yield return grandChild;
             }
         }
+
+        public static bool IsColourSet(this SvgPaintServer colour)
+        {
+            return colour != null && colour != SvgColourServer.None && colour != SvgColourServer.NotSet;
+        }
+        public static bool HasStroke(this SvgVisualElement element)
+        {
+            return element.Stroke.IsColourSet();
+        }
+
+        public static bool HasFill(this SvgVisualElement element)
+        {
+            return element.Fill.IsColourSet();
+        }
+
+        
     }
 }

--- a/Svg/SvgHitTestingExtensions.cs
+++ b/Svg/SvgHitTestingExtensions.cs
@@ -1,0 +1,311 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Svg.Interfaces;
+using Svg.Transforms;
+
+namespace Svg
+{
+    public enum SelectionType
+    {
+        Intersect,
+        IntersectBoundingBoxes,
+        Contain
+    }
+
+    public enum HitTestResultMode
+    {
+        /// <summary>
+        /// If the hit test finds a child/descendant element being hit at the coordinates, this element is returned
+        /// </summary>
+        ReturnAllMatchingDescendants = 0,
+        /// <summary>
+        /// If the hit test finds a child/descendant element being hit at the coordinates, returns the root element (this element)
+        /// </summary>
+        ReturnRootElementOnly = 1,
+    }
+
+    /// <summary>
+    /// Hit test book explaining the math behind all this:
+    /// https://www.jeffreythompson.org/collision-detection/
+    /// </summary>
+    public static class SvgHitTestingExtensions
+    {
+        public static IEnumerable<TElement> HitTest<TElement>(this SvgDocument doc,
+            RectangleF rectangle,
+            SelectionType selectionType = SelectionType.Intersect,
+            HitTestResultMode hitTestResultMode = HitTestResultMode.ReturnAllMatchingDescendants,
+            Matrix matrix = null,
+            int maxRecursion = int.MaxValue) where TElement : SvgVisualElement
+        {
+            matrix ??= Matrix.Create();
+            foreach (var transform in doc.Transforms)
+                transform.ApplyTo(matrix);
+
+            return doc.Children.OfType<SvgVisualElement>()
+                // reverse for correct z-order!
+                .Reverse()
+                .SelectMany(e =>
+                    e.HitTest<TElement>(rectangle, selectionType, hitTestResultMode, matrix, maxRecursion));
+        }
+
+        public static IEnumerable<TElement> HitTest<TElement>(this SvgVisualElement e, 
+            RectangleF rectangle,
+            SelectionType selectionType = SelectionType.Intersect,
+            HitTestResultMode hitTestResultMode = HitTestResultMode.ReturnAllMatchingDescendants,
+            Matrix transform = null,
+            int maxRecursion = int.MaxValue) where TElement : SvgVisualElement
+        {
+            return e.HitTestInternal<TElement>(rectangle, selectionType, hitTestResultMode, transform ?? Matrix.Create(), maxRecursion);
+        }
+
+        public static IEnumerable<TElement> HitTestInternal<TElement>(this SvgVisualElement e, RectangleF rectangle,
+            SelectionType selectionType,
+            HitTestResultMode hitTestResultMode,
+            Matrix transform,
+            int maxRecursion) where TElement : SvgVisualElement
+        {
+            if (transform == null)
+                transform = Matrix.Create();
+            else
+                transform = transform.Clone();
+
+            bool IsIntersect(SelectionType st) => st == SelectionType.Intersect || st == SelectionType.IntersectBoundingBoxes;
+            bool WithBoundingBoxOnly(SelectionType st) => st == SelectionType.IntersectBoundingBoxes;
+
+            if (e.Renderable)
+            {
+                var pts = e.GetTransformedElementPoints(transform);
+                var box = RectangleF.FromPoints(pts);
+
+                // in certain edge cases, the bounding box can be so 
+                if (IsIntersect(selectionType))
+                    box = box.InflateAndCopy(rectangle.Width, rectangle.Height);
+
+                // if this element fits the type filter, check if it fits the hittest rectangle
+                if (e is TElement te)
+                {
+                    if (IsIntersect(selectionType) && rectangle.IntersectsWith(box))
+                    {
+                        if (WithBoundingBoxOnly(selectionType) || e.IntersectsWith(rectangle, transform, maxRecursion))
+                            yield return te;
+                    }
+                    else if ((selectionType == SelectionType.Contain) && rectangle.Contains(box))
+                        yield return te;
+                }
+            }
+            else
+            {
+                // recurse the hittest to the inner levels
+                var recurs = maxRecursion - 1;
+                if (recurs > 0)
+                {
+                    var t2 = transform.Clone();
+                    foreach (SvgTransform transformation in e.Transforms)
+                    {
+                        transformation.ApplyTo(t2);
+                    }
+
+                    if (hitTestResultMode == HitTestResultMode.ReturnAllMatchingDescendants)
+                    {
+                        // reverse children because of z-index
+                        foreach (var hit in e.Children.Reverse().OfType<SvgVisualElement>()
+                                     .SelectMany(child =>
+                                         child.HitTestInternal<TElement>(rectangle, selectionType, hitTestResultMode, t2,
+                                             recurs)))
+                        {
+                            yield return hit;
+                        }
+                    }
+                    // if root element is selected, and any child is hit
+                    else if (hitTestResultMode == HitTestResultMode.ReturnRootElementOnly &&
+                             e is TElement te &&
+                             e.Children.Reverse().OfType<SvgVisualElement>()
+                                 .SelectMany(child =>
+                                     child.HitTestInternal<TElement>(rectangle, selectionType, hitTestResultMode, t2,
+                                         recurs)).Any())
+                    {
+                        yield return te;
+                        // we already found that the root element is a result, so we need not search further
+                        yield break;
+                    }
+                }
+                 
+                // if this element fits the type filter, check if it fits the hit test rectangle
+                if (e is TElement elt)
+                {
+                    var points = e.GetTransformedChildPoints(transform);
+                    var box = RectangleF.FromPoints(points);
+
+                    if (IsIntersect(selectionType))
+                        box = box.InflateAndCopy(rectangle.Width, rectangle.Height);
+
+                    if (IsIntersect(selectionType) && rectangle.IntersectsWith(box))
+                    {
+                        if (WithBoundingBoxOnly(selectionType) || e.IntersectsWith(rectangle, transform, maxRecursion))
+                            yield return elt;
+                    }
+                    else if ((selectionType == SelectionType.Contain) && rectangle.Contains(box))
+                        yield return elt;
+                }
+            }
+        }
+
+        internal static PointF[] GetTransformedElementPoints(this SvgVisualElement e, Matrix transform)
+        {
+            var b = e.Bounds;
+            var p1 = PointF.Create(b.Left, b.Top);
+            var p2 = PointF.Create(b.Right, b.Top);
+            var p3 = PointF.Create(b.Right, b.Bottom);
+            var p4 = PointF.Create(b.Left, b.Bottom);
+
+            var pts = new[] { p1, p2, p3, p4 };
+
+            foreach (SvgTransform transformation in e.Transforms)
+            {
+                transformation.ApplyTo(transform);
+            }
+
+            transform.TransformPoints(pts);
+            return pts.Select(p => p.Clone()).ToArray();
+        }
+
+        internal static PointF[] GetTransformedChildPoints(this SvgVisualElement e, Matrix transform)
+        {
+            var pts = new List<PointF>();
+
+            foreach (SvgTransform transformation in e.Transforms)
+            {
+                transformation.ApplyTo(transform);
+            }
+
+            foreach (var c in e.Children)
+            {
+                if (c is SvgVisualElement)
+                {
+                    var childBounds = ((SvgVisualElement)c).GetTransformedPoints(transform);
+                    pts.AddRange(childBounds);
+                }
+            }
+            return pts.Select(p => p.Clone()).ToArray();
+        }
+
+        /// <summary>
+        /// provide the list of points, the transformed tap point and the matrix of the current element.
+        /// Applies the matrix to all points and checks if the line intersects with a cube with center = "tap" and radius ="selectionWidthHeight"
+        /// </summary>
+        /// <param name="lines">the line segments to check</param>
+        /// <param name="transform">the total transformation matrix for the current lines</param>
+        /// <param name="hitTestArea">the area we want to intersect with the lines</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        public static bool IsIntersectingWithLine(this IList<(PointF from, PointF to)> lines, Matrix transform, RectangleF hitTestArea)
+        {
+            if (lines == null) throw new ArgumentNullException(nameof(lines));
+            if (transform == null) throw new ArgumentNullException(nameof(transform));
+            if (hitTestArea == null) throw new ArgumentNullException(nameof(hitTestArea));
+
+            PointF tap = hitTestArea.GetCenterPoint();
+            double selectionWidthHeight = hitTestArea.Width / 2;
+
+            foreach (var lineSegment in lines)
+            {
+                transform.TransformPoints(new[] { lineSegment.from, lineSegment.to });
+                if (IsLineHit(lineSegment.from, lineSegment.to, tap, selectionWidthHeight))
+                    return true;
+            }
+
+            return false;
+        }
+        /// <summary>
+        /// provide a line segment (from, to), the transformed tap point and the matrix of the current element.
+        /// Applies the matrix to all points and checks if the line intersects with a cube with center = "tap" and radius ="selectionWidthHeight"
+        /// </summary>
+        /// <param name="lineSegment">the line segments to check</param>
+        /// <param name="transform">the total transformation matrix for the current lines</param>
+        /// <param name="hitTestArea">the area we want to intersect with the lines</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        public static bool IsIntersectingWithLine(this (PointF from, PointF to) lineSegment, Matrix transform, RectangleF hitTestArea)
+        {
+            if (transform == null) throw new ArgumentNullException(nameof(transform));
+            if (hitTestArea == null) throw new ArgumentNullException(nameof(hitTestArea));
+
+            PointF tap = hitTestArea.GetCenterPoint();
+            double selectionWidthHeight = hitTestArea.Width / 2;
+
+
+            transform.TransformPoints(new[] { lineSegment.from, lineSegment.to });
+
+            if (IsLineHit(lineSegment.from, lineSegment.to, tap, selectionWidthHeight))
+                return true;
+         
+            return false;
+        }
+
+        /// <summary>
+        /// Google paste https://stackoverflow.com/a/13741803/333571
+        /// </summary>
+        /// <param name="start"></param>
+        /// <param name="end"></param>
+        /// <param name="point"></param>
+        /// <param name="selectionWidthHeight"></param>
+        /// <returns></returns>
+        private static bool IsLineHit(PointF start, PointF end, PointF point, double selectionWidthHeight)
+        {
+            PointF leftPoint;
+            PointF rightPoint;
+
+            // Normalize start/end to left right to make the offset calc simpler.
+            if (start.X <= end.X)
+            {
+                leftPoint = start;
+                rightPoint = end;
+            }
+            else
+            {
+                leftPoint = end;
+                rightPoint = start;
+            }
+
+            // If point is out of bounds, no need to do further checks.                  
+            if (point.X + selectionWidthHeight < leftPoint.X || rightPoint.X < point.X - selectionWidthHeight)
+                return false;
+            if (point.Y + selectionWidthHeight < Math.Min(leftPoint.Y, rightPoint.Y) ||
+                Math.Max(leftPoint.Y, rightPoint.Y) < point.Y - selectionWidthHeight)
+                return false;
+
+            // https://de.wikipedia.org/wiki/Lineare_Funktion
+            double deltaX = rightPoint.X - leftPoint.X;
+            double deltaY = rightPoint.Y - leftPoint.Y;
+
+            // If the line is straight, the earlier boundary check is enough to determine that the point is on the line.
+            // Also prevents division by zero exceptions.
+            if (deltaX == 0 || deltaY == 0)
+                return true;
+
+            double slope = deltaY / deltaX;
+            double offset = leftPoint.Y - leftPoint.X * slope;
+            double calculatedY = point.X * slope + offset;
+
+            //adjustment of offset 
+            double c = point.Y - offset - slope * point.X;
+
+            double actualX = (point.Y - offset) / slope;
+            double outOfBounds = point.X - actualX >= 0 ? point.X - actualX : actualX - point.X;
+
+            if (Math.Abs(outOfBounds) > selectionWidthHeight && Math.Abs(c) > selectionWidthHeight)
+            {
+                return false;
+            }
+
+            calculatedY += c;
+
+            //Check calculated Y matches the points Y coord with some easing.
+            bool lineContains = point.Y - selectionWidthHeight <= calculatedY &&
+                                calculatedY <= point.Y + selectionWidthHeight;
+
+            return lineContains;
+        }
+    }
+}

--- a/Svg/Transforms/SvgMatrix.cs
+++ b/Svg/Transforms/SvgMatrix.cs
@@ -69,6 +69,11 @@ namespace Svg.Transforms
         	this.points = m;
         }
 
+        public SvgMatrix(Matrix m)
+        {
+        	this.points = new List<float>{m.ScaleX,m.SkewX,m.SkewY,m.ScaleY,m.OffsetX,m.OffsetY};
+        }
+
 
 		public override object Clone()
 		{


### PR DESCRIPTION
Svg.Editor.* 2.4.3.3
 - canvas automatically ignores all hittestinvisible items
 - svg path/rect/polyline/polygon/line now support hit-testing of its line instead of the full bounding box in case no fill is applied
 - refactored hit-testing
 - added tests for intersection hit-testing
 - fixed matrix calculation