### PR TITLE
Svg Path HitTest

### DIFF
--- a/Svg.Tests.Win/GetSvgPathAsLinesTests.cs
+++ b/Svg.Tests.Win/GetSvgPathAsLinesTests.cs
@@ -1,0 +1,47 @@
+﻿using System.Linq;
+using FluentAssertions;
+using FluentAssertions.Common;
+using NUnit.Framework;
+using Svg.Interfaces;
+using Svg.Pathing;
+
+namespace Svg.Tests.Win
+{
+    [TestFixture]
+    public class GetSvgPathAsLinesTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            SvgPlatform.Init();
+        }
+
+        [Test]
+        public void GivenSvgPathSegmentList_ReturnsAllVisibleLines()
+        {
+            //Arrange
+            var svgPathSegmentList = new SvgPathSegmentList
+            {
+                new SvgMoveToSegment(PointF.Create(50, 250)),
+                new SvgLineSegment(PointF.Create(50, 250), PointF.Create(50, 50)),
+                new SvgLineSegment(PointF.Create(50, 50), PointF.Create(250, 50)),
+                new SvgClosePathSegment(),
+                new SvgMoveToSegment(PointF.Create(8, 650))
+            };
+            
+            var expected = new []
+            {
+                (PointF.Create(50,250), PointF.Create(50,50)),
+                (PointF.Create(50,50), PointF.Create(250,50)),
+                (PointF.Create(250,50), PointF.Create(50,250)),
+            }.ToList();
+
+            //Act
+            var actual = svgPathSegmentList.GetLines();
+
+            //Assert
+            actual.Should().Equal(expected);
+
+        }
+    }
+}

--- a/Svg.Tests.Win/Svg.Tests.Win.csproj
+++ b/Svg.Tests.Win/Svg.Tests.Win.csproj
@@ -70,6 +70,7 @@
     <Compile Include="SvgHitTests_PolyLine.cs" />
     <Compile Include="SvgHitTests_Line.cs" />
     <Compile Include="SvgHitTests_Rectangle.cs" />
+    <Compile Include="SvgHitTest_Path.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/Svg.Tests.Win/Svg.Tests.Win.csproj
+++ b/Svg.Tests.Win/Svg.Tests.Win.csproj
@@ -63,6 +63,7 @@
     <Compile Include="..\Svg.Editor.Tests.Win\FileLoader.cs">
       <Link>FileLoader.cs</Link>
     </Compile>
+    <Compile Include="GetSvgPathAsLinesTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SaveDocumentTests.cs" />
     <Compile Include="SvgHitTests.cs" />

--- a/Svg.Tests.Win/SvgHitTest_Path.cs
+++ b/Svg.Tests.Win/SvgHitTest_Path.cs
@@ -1,0 +1,84 @@
+﻿using System.Linq;
+using FluentAssertions;
+using NUnit.Framework;
+using Svg.Interfaces;
+
+namespace Svg.Tests.Win
+{
+    [TestFixture]
+    public class SvgHitTest_Path
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            SvgPlatform.Init();
+        }
+
+        [TestCase("outside tap w/o fill", SelectionType.Intersect, 120, 350, 10, "none", false)]
+        [TestCase("outside tap w fill", SelectionType.Intersect, 120, 350, 10, "lime", false)]
+        [TestCase("first line tap w/o fill", SelectionType.Intersect, 50, 150, 10, "none", true)]
+        [TestCase("~first line tap w/o fill", SelectionType.Intersect, 50, 150, 10, "none", true)]
+        [TestCase("second line tap w/o fill", SelectionType.Intersect, 150, 50, 10, "none", true)]
+        [TestCase("~second line tap w/o fill", SelectionType.Intersect, 150, 50, 10, "none", true)]
+        [TestCase("third line tap w/o fill", SelectionType.Intersect, 300, 150, 10, "none", true)]
+        [TestCase("~third line tap w/o fill", SelectionType.Intersect, 300, 150, 10, "none", true)]
+        //[TestCase("NOT EXISTNG fourth line tap w/o fill", SelectionType.Intersect, 45, 150, 10, "none", false)]
+        //[TestCase("NOT EXISTNG ~fourth line tap w/o fill", SelectionType.Intersect, 40, 150, 10, "none", false)]
+        public void IsHit(string ___, SelectionType selectionType, float x, float y, float wh, string fill, bool expectsHitSuccessful)
+        {
+            // Arrange
+            var rawSvg = $@"
+<svg height=""500"" width=""500"">
+  <path d=""M50 250 L50 50 L300 50 L300 250"" fill=""{fill}"" stroke =""black""/>
+</svg>";
+            var svg = SvgDocument.FromSvg<SvgDocument>(rawSvg);
+            var rect = RectangleF.Create(x, y, wh, wh);
+
+            var path = new SvgPath();
+
+            // Act
+            var result = svg.HitTest<SvgVisualElement>(rect, selectionType);
+
+            // Assert
+            if (!expectsHitSuccessful)
+                result.Should().BeEmpty();
+            else
+                result.Should().HaveCount(1);
+        }
+
+        [TestCase("outside tap w/o fill", SelectionType.Intersect, 120, 350, 10, "none", false)]
+        [TestCase("outside tap w fill", SelectionType.Intersect, 120, 350, 10, "lime", false)]
+        [TestCase("first line tap w/o fill", SelectionType.Intersect, 50, 150, 10, "none", true)]
+        [TestCase("~first line tap w/o fill", SelectionType.Intersect, 50, 150, 10, "none", true)]
+        [TestCase("second line tap w/o fill", SelectionType.Intersect, 150, 50, 10, "none", true)]
+        [TestCase("~second line tap w/o fill", SelectionType.Intersect, 150, 50, 10, "none", true)]
+        [TestCase("third line tap w/o fill", SelectionType.Intersect, 300, 150, 10, "none", true)]
+        [TestCase("~third line tap w/o fill", SelectionType.Intersect, 300, 150, 10, "none", true)]
+        public void OnPannedZoomedCanvas_IsHit(string ___, SelectionType selectionType, float x, float y, float wh, string fill, bool expectsHitSuccessful)
+        {
+            // Arrange
+            var rawSvg = $@"
+<svg height=""500"" width=""500"">
+  <path d=""M50 250 L50 50 L300 50 L300 250"" fill=""{fill}"" stroke =""black""/>
+</svg>";
+            var svg = SvgDocument.FromSvg<SvgDocument>(rawSvg);
+            var rect = RectangleF.Create(x, y, wh, wh);
+
+            // simulate user zooming and panning
+            var canvasMatrix = Matrix.Create();
+            canvasMatrix.Translate(100, 200);
+            canvasMatrix.Scale(3, 3);
+            // and selecting some rectangle on panned&zoomed canvas
+            rect = canvasMatrix.TransformRectangle(rect);
+
+            // Act
+            var result = svg.HitTest<SvgVisualElement>(rect, selectionType, matrix: canvasMatrix);
+
+            // Assert
+            if (!expectsHitSuccessful)
+                result.Should().BeEmpty();
+            else
+                result.Should().HaveCount(1);
+        }
+    }
+}

--- a/Svg.Tests.Win/SvgHitTest_Path.cs
+++ b/Svg.Tests.Win/SvgHitTest_Path.cs
@@ -17,24 +17,25 @@ namespace Svg.Tests.Win
         [TestCase("outside tap w/o fill", SelectionType.Intersect, 120, 350, 10, "none", false)]
         [TestCase("outside tap w fill", SelectionType.Intersect, 120, 350, 10, "lime", false)]
         [TestCase("first line tap w/o fill", SelectionType.Intersect, 50, 150, 10, "none", true)]
-        [TestCase("~first line tap w/o fill", SelectionType.Intersect, 50, 150, 10, "none", true)]
+        [TestCase("~first line tap w/o fill", SelectionType.Intersect, 48, 150, 10, "none", true)]
         [TestCase("second line tap w/o fill", SelectionType.Intersect, 150, 50, 10, "none", true)]
-        [TestCase("~second line tap w/o fill", SelectionType.Intersect, 150, 50, 10, "none", true)]
+        [TestCase("~second line tap w/o fill", SelectionType.Intersect, 150, 46, 10, "none", true)]
         [TestCase("third line tap w/o fill", SelectionType.Intersect, 300, 150, 10, "none", true)]
-        [TestCase("~third line tap w/o fill", SelectionType.Intersect, 300, 150, 10, "none", true)]
-        //[TestCase("NOT EXISTNG fourth line tap w/o fill", SelectionType.Intersect, 45, 150, 10, "none", false)]
-        //[TestCase("NOT EXISTNG ~fourth line tap w/o fill", SelectionType.Intersect, 40, 150, 10, "none", false)]
+        [TestCase("~third line tap w/o fill", SelectionType.Intersect, 298, 150, 10, "none", true)]
+        [TestCase("fourth line tap w/o fill", SelectionType.Intersect, 150, 250, 10, "none", true)]
+        [TestCase("~fourth line tap w/o fill", SelectionType.Intersect, 150, 247, 10, "none", true)]
+        [TestCase("fifth line tap w/o fill", SelectionType.Intersect, 150, 300, 10, "none", true)]
+        [TestCase("~fifth line tap w/o fill", SelectionType.Intersect, 152, 300, 10, "none", true)]
+        [TestCase("Between M and Z", SelectionType.Intersect, 50, 260, 10, "none", false)]
         public void IsHit(string ___, SelectionType selectionType, float x, float y, float wh, string fill, bool expectsHitSuccessful)
         {
             // Arrange
             var rawSvg = $@"
 <svg height=""500"" width=""500"">
-  <path d=""M50 250 L50 50 L300 50 L300 250"" fill=""{fill}"" stroke =""black""/>
+  <path d=""M50 250 L50 50 H300 V250 Z M150 300 L400 400"" fill=""none"" stroke =""black""/>
 </svg>";
             var svg = SvgDocument.FromSvg<SvgDocument>(rawSvg);
             var rect = RectangleF.Create(x, y, wh, wh);
-
-            var path = new SvgPath();
 
             // Act
             var result = svg.HitTest<SvgVisualElement>(rect, selectionType);
@@ -49,17 +50,23 @@ namespace Svg.Tests.Win
         [TestCase("outside tap w/o fill", SelectionType.Intersect, 120, 350, 10, "none", false)]
         [TestCase("outside tap w fill", SelectionType.Intersect, 120, 350, 10, "lime", false)]
         [TestCase("first line tap w/o fill", SelectionType.Intersect, 50, 150, 10, "none", true)]
-        [TestCase("~first line tap w/o fill", SelectionType.Intersect, 50, 150, 10, "none", true)]
+        [TestCase("~first line tap w/o fill", SelectionType.Intersect, 48, 150, 10, "none", true)]
         [TestCase("second line tap w/o fill", SelectionType.Intersect, 150, 50, 10, "none", true)]
-        [TestCase("~second line tap w/o fill", SelectionType.Intersect, 150, 50, 10, "none", true)]
+        [TestCase("~second line tap w/o fill", SelectionType.Intersect, 150, 46, 10, "none", true)]
         [TestCase("third line tap w/o fill", SelectionType.Intersect, 300, 150, 10, "none", true)]
-        [TestCase("~third line tap w/o fill", SelectionType.Intersect, 300, 150, 10, "none", true)]
+        [TestCase("~third line tap w/o fill", SelectionType.Intersect, 298, 150, 10, "none", true)]
+        [TestCase("fourth line tap w/o fill", SelectionType.Intersect, 150, 250, 10, "none", true)]
+        [TestCase("~fourth line tap w/o fill", SelectionType.Intersect, 150, 247, 10, "none", true)]
+        [TestCase("fifth line tap w/o fill", SelectionType.Intersect, 150, 300, 10, "none", true)]
+        [TestCase("~fifth line tap w/o fill", SelectionType.Intersect, 152, 300, 10, "none", true)]
+        [TestCase("Between M and Z", SelectionType.Intersect, 50, 260, 10, "none", false)]
+
         public void OnPannedZoomedCanvas_IsHit(string ___, SelectionType selectionType, float x, float y, float wh, string fill, bool expectsHitSuccessful)
         {
             // Arrange
             var rawSvg = $@"
 <svg height=""500"" width=""500"">
-  <path d=""M50 250 L50 50 L300 50 L300 250"" fill=""{fill}"" stroke =""black""/>
+  <path d=""M50 250 L50 50 H300 V250 Z M150 300 L400 400"" fill=""none"" stroke =""black""/>
 </svg>";
             var svg = SvgDocument.FromSvg<SvgDocument>(rawSvg);
             var rect = RectangleF.Create(x, y, wh, wh);

--- a/Svg/Paths/SvgPath.cs
+++ b/Svg/Paths/SvgPath.cs
@@ -165,11 +165,11 @@ namespace Svg
             if (this.HasFill())
                 return true;
 
-            var lineSegments = this.PathData.Select(seg => (seg.Start, seg.End)).ToList();
-            lineSegments.RemoveAt(0);
-
-            return lineSegments.IsIntersectingWithLinePaths(transform, rectangle);
+            var lineSegments = PathData.GetLines();
+            
+            return lineSegments.IsIntersectingWithLine(transform, rectangle);
         }
+
 
         public override SvgElement DeepCopy()
 		{

--- a/Svg/Paths/SvgPath.cs
+++ b/Svg/Paths/SvgPath.cs
@@ -166,8 +166,9 @@ namespace Svg
                 return true;
 
             var lineSegments = this.PathData.Select(seg => (seg.Start, seg.End)).ToList();
+            lineSegments.RemoveAt(0);
 
-            return lineSegments.IsIntersectingWithLine(transform, rectangle);
+            return lineSegments.IsIntersectingWithLinePaths(transform, rectangle);
         }
 
         public override SvgElement DeepCopy()

--- a/Svg/SvgHitTestingExtensions.cs
+++ b/Svg/SvgHitTestingExtensions.cs
@@ -242,33 +242,6 @@ namespace Svg
          
             return false;
         }
-        public static bool IsIntersectingWithLinePaths(this IList<(PointF from, PointF to)> lines, Matrix transform, RectangleF hitTestArea)
-        {
-            if (lines == null) throw new ArgumentNullException(nameof(lines));
-            if (transform == null) throw new ArgumentNullException(nameof(transform));
-            if (hitTestArea == null) throw new ArgumentNullException(nameof(hitTestArea));
-
-            PointF tap = hitTestArea.GetCenterPoint();
-            double selectionWidthHeight = hitTestArea.Width / 2;
-
-            int i = 0;
-            foreach (var lineSegment in lines)
-            {
-                if (i == 0)
-                {
-                    transform.TransformPoints(new[] { lineSegment.from, lineSegment.to });
-                    i++;
-                }
-                else
-                {
-                    transform.TransformPoints(new[] { lineSegment.to });
-                }
-                if (IsLineHit(lineSegment.from, lineSegment.to, tap, selectionWidthHeight))
-                    return true;
-            }
-
-            return false;
-        }
 
         /// <summary>
         /// Google paste https://stackoverflow.com/a/13741803/333571

--- a/Svg/SvgHitTestingExtensions.cs
+++ b/Svg/SvgHitTestingExtensions.cs
@@ -242,6 +242,33 @@ namespace Svg
          
             return false;
         }
+        public static bool IsIntersectingWithLinePaths(this IList<(PointF from, PointF to)> lines, Matrix transform, RectangleF hitTestArea)
+        {
+            if (lines == null) throw new ArgumentNullException(nameof(lines));
+            if (transform == null) throw new ArgumentNullException(nameof(transform));
+            if (hitTestArea == null) throw new ArgumentNullException(nameof(hitTestArea));
+
+            PointF tap = hitTestArea.GetCenterPoint();
+            double selectionWidthHeight = hitTestArea.Width / 2;
+
+            int i = 0;
+            foreach (var lineSegment in lines)
+            {
+                if (i == 0)
+                {
+                    transform.TransformPoints(new[] { lineSegment.from, lineSegment.to });
+                    i++;
+                }
+                else
+                {
+                    transform.TransformPoints(new[] { lineSegment.to });
+                }
+                if (IsLineHit(lineSegment.from, lineSegment.to, tap, selectionWidthHeight))
+                    return true;
+            }
+
+            return false;
+        }
 
         /// <summary>
         /// Google paste https://stackoverflow.com/a/13741803/333571

--- a/Svg/SvgPathSegmentListExtension.cs
+++ b/Svg/SvgPathSegmentListExtension.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Svg.Interfaces;
+using Svg.Pathing;
+
+namespace Svg
+{
+    public static class SvgPathSegmentListExtension
+    {
+        public static List<(PointF start, PointF end)> GetLines(this SvgPathSegmentList pathSegmentList)
+        {
+
+            var newPathData = new SvgPathSegmentList();
+            for (int i = 0; i < pathSegmentList.Count; i++)
+            {
+                if (pathSegmentList[i].ToString().Contains("M"))
+                    continue;
+                if (pathSegmentList[i].ToString() == "z")
+                {
+                    newPathData.Add(new SvgLineSegment(pathSegmentList[i - 1].End, pathSegmentList[0].Start));
+                    continue;
+                }
+
+                newPathData.Add(pathSegmentList[i]);
+            }
+
+            return newPathData.Select(seg => (seg.Start.Clone(), seg.End.Clone())).ToList();
+
+        }
+    }
+}


### PR DESCRIPTION
Kurzfristige aber funktionelle Lösung: 

-) Erstes` lineSegment entfernen weil es nur der selbe Punkt ist (z.B. 50 50, 50 50)

-) Nur beim  ersten mal darf ich den Start- und Endpunkt transformieren. Danach nur den Endpunkt, da der Startpunkt vorher ein Endpunkt war und transformiert wurde und sonst die liste ändern würde.