### PR TITLE
📦 Svg.* 2.4.3.4

### DIFF
--- a/Svg.Editor.Core.Tests/PanToolTests.cs
+++ b/Svg.Editor.Core.Tests/PanToolTests.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Svg.Editor.Interfaces;
+using Svg.Editor.Tools;
+
+namespace Svg.Editor.Core.Test
+{
+    [TestFixture]
+    public class PanToolTests : SvgDrawingCanvasTestBase
+    {
+        [SetUp]
+        protected override void SetupOverride()
+        {
+            Canvas.LoadTools(
+                () => new SelectionTool(SvgEngine.Resolve<IUndoRedoService>()),
+                () => new PanTool(new Dictionary<string, object>()));
+        }
+
+        [Test]
+        public async Task WhenInitialized_PanToolIsAutomaticallyEnabled()
+        {
+            // Arrange
+            var tool = Canvas.Tools.OfType<PanTool>().Single();
+
+            // Act
+            await Canvas.EnsureInitialized();
+
+            // Assert
+            Assert.True(tool.IsActive, "should be active by default");
+        }
+    }
+}

--- a/Svg.Editor.Core.Tests/Svg.Editor.Core.Tests.csproj
+++ b/Svg.Editor.Core.Tests/Svg.Editor.Core.Tests.csproj
@@ -70,6 +70,7 @@
     <Compile Include="IFIleLoader.cs" />
     <Compile Include="LineToolTests.cs" />
     <Compile Include="Mocks\MockTextInputService.cs" />
+    <Compile Include="PanToolTests.cs" />
     <Compile Include="MoveToolTests.cs" />
     <Compile Include="PerformanceTests.cs" />
     <Compile Include="RotationToolTests.cs" />

--- a/Svg.Editor.Core/Svg.Editor.Core.csproj
+++ b/Svg.Editor.Core/Svg.Editor.Core.csproj
@@ -4,8 +4,11 @@
     <AssemblyName>Svg.Editor</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>2.4.3.3</Version>
+    <Version>2.4.3.4</Version>
     <PackageReleaseNotes>
+        # 2.4.3.4
+        - fixed for plan rendering
+        - polygon tool improvements (selection rendered on adorner layer)
 	    # 2.4.3.3
 	    - polygon tool
 	    - hit testing basic shapes without fill tests line intersection
@@ -64,7 +67,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="SkiaSharp" Version="1.68.1" />
-    <PackageReference Include="Svg" Version="2.4.3.3" />
+    <PackageReference Include="Svg" Version="2.4.3.4" />
     <PackageReference Include="System.Reactive" Version="4.0.0" />
     <PackageReference Include="Xamarin.Forms" Version="4.1.0.778454" />
   </ItemGroup>

--- a/Svg.Editor.Core/Tools/ColorTool.cs
+++ b/Svg.Editor.Core/Tools/ColorTool.cs
@@ -161,8 +161,8 @@ namespace Svg.Editor.Tools
 
 		private void ColorizeElement(SvgElement element, int colorIndex)
 		{
-			var noFill = element.HasConstraints(NoFillConstraint);
-			var noStroke = element.HasConstraints(NoStrokeConstraint);
+			var noFill = element.Fill == null ||element.Fill == SvgPaintServer.None || element.HasConstraints(NoFillConstraint);
+			var noStroke = element.Stroke == null || element.Stroke == SvgPaintServer.None || element.HasConstraints(NoStrokeConstraint);
 
 			// only colorize visual elements
 			if (!(element is SvgVisualElement) || noFill && noStroke) return;

--- a/Svg.Editor.Core/Tools/FreeDrawingTool.cs
+++ b/Svg.Editor.Core/Tools/FreeDrawingTool.cs
@@ -60,13 +60,6 @@ namespace Svg.Editor.Tools
 
         #region Overrides
 
-        public override async Task Initialize(ISvgDrawingCanvas ws)
-        {
-            await base.Initialize(ws);
-
-            IsActive = false;
-        }
-
         public override void OnDocumentChanged(SvgDocument oldDocument, SvgDocument newDocument)
         {
             if (oldDocument != null) UnWatchDocument(oldDocument);

--- a/Svg.Editor.Core/Tools/LineTool.cs
+++ b/Svg.Editor.Core/Tools/LineTool.cs
@@ -372,9 +372,7 @@ namespace Svg.Editor.Tools
 		public override async Task Initialize(ISvgDrawingCanvas ws)
 		{
 			await base.Initialize(ws);
-
-			IsActive = false;
-
+			
 			Commands = new List<IToolCommand>
 			{
 				new ChangeLineStyleCommand(ws, this, "Line endings")

--- a/Svg.Editor.Core/Tools/MoveTool.cs
+++ b/Svg.Editor.Core/Tools/MoveTool.cs
@@ -32,13 +32,6 @@ namespace Svg.Editor.Tools
 
         public override int InputOrder => 200; // must be before pantool as it decides whether or not it is active based on selection
 
-        public override async Task Initialize(ISvgDrawingCanvas ws)
-        {
-            await base.Initialize(ws);
-
-            IsActive = false;
-        }
-
         protected override async Task OnDrag(DragGesture drag)
         {
             await base.OnDrag(drag);

--- a/Svg.Editor.Core/Tools/PanTool.cs
+++ b/Svg.Editor.Core/Tools/PanTool.cs
@@ -14,6 +14,12 @@ namespace Svg.Editor.Tools
             ToolType = ToolType.View;
         }
 
+        public override Task Initialize(ISvgDrawingCanvas ws)
+        {
+            IsActive = true;
+            return base.Initialize(ws);
+        }
+
         public override Task OnUserInput(UserInputEvent @event, ISvgDrawingCanvas ws)
         {
             if (!IsActive)

--- a/Svg.Editor.Core/Tools/PinTool.cs
+++ b/Svg.Editor.Core/Tools/PinTool.cs
@@ -1,18 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
-using System.Xml.Serialization;
-using Newtonsoft.Json;
-using Svg.Editor.Extensions;
 using Svg.Editor.Gestures;
 using Svg.Editor.Interfaces;
 using Svg.Editor.UndoRedo;
-using Svg.Editor.Utils;
 using Svg.Interfaces;
-using Svg.Platform;
 using Svg.Transforms;
 
 namespace Svg.Editor.Tools
@@ -94,9 +87,7 @@ namespace Svg.Editor.Tools
         public override async Task Initialize(ISvgDrawingCanvas ws)
         {
             await base.Initialize(ws);
-
-            IsActive = false;
-
+            
             _textInputService = SvgEngine.TryResolve<ITextInputService>();
             _pinInputService = SvgEngine.TryResolve<IPinInputService>();
             _text = "";

--- a/Svg.Editor.Core/Tools/PolygonTool.cs
+++ b/Svg.Editor.Core/Tools/PolygonTool.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 using Svg.Editor.Extensions;
 using Svg.Editor.Gestures;
 using Svg.Editor.Interfaces;
-using Svg.Pathing;
+using Svg.Interfaces;
 using PointF = Svg.Interfaces.PointF;
 
 namespace Svg.Editor.Tools
@@ -20,9 +20,13 @@ namespace Svg.Editor.Tools
             ToolType = ToolType.Create;
         }
 
-        private const string PolygonTempAttributeKey = "data-polytemp";
-
         private bool _isActive;
+        private Brush _brush;
+        private Pen _pen;
+        private Brush _circleBrush;
+        private Brush PolyLineBrush => _brush ?? (_brush = SvgEngine.Factory.CreateSolidBrush(SvgEngine.Factory.CreateColorFromArgb(125, 80, 210, 210)));
+        private Pen PolyLinePen => _pen ?? (_pen = SvgEngine.Factory.CreatePen(PolyLineBrush, 5));
+        private Brush PolyCircleBrush => _circleBrush ?? (_circleBrush = SvgEngine.Factory.CreateSolidBrush(SvgEngine.Factory.CreateColorFromArgb(255, 80, 210, 210)));
 
         public override bool IsActive
         {
@@ -34,14 +38,7 @@ namespace Svg.Editor.Tools
                     Reset();
             }
         }
-
-        public override async Task Initialize(ISvgDrawingCanvas ws)
-        {
-            await base.Initialize(ws);
-
-            IsActive = false;
-        }
-
+        
         public const string DefaultStrokeWidthKey = "defaultstrokewidth";
 
         public int DefaultStrokeWidth
@@ -55,7 +52,9 @@ namespace Svg.Editor.Tools
             }
             set => Properties[DefaultStrokeWidthKey] = value;
         }
+        
         public IList<PointF> Points { get; } = new List<PointF>();
+
         protected override async Task OnTap(TapGesture tap)
         {
             await base.OnTap(tap);
@@ -65,28 +64,50 @@ namespace Svg.Editor.Tools
             if (!IsActive) return;
 
             Canvas.SelectedElements.Clear();
-
-            if (Points.Count > 0)
+            
+            //Closing the polygon
+            if (Points.Count > 0 && IsClickingOnFirstPoint(point))
             {
-                //Closing the polygon
-                if (IsClickingOnFirstPoint(point))
+                if (!IsValidPolgyon(Points))
+                {
+                    Reset();
+                }
+                else
                 {
                     DrawPolygon();
                     Reset();
                     Canvas.ActiveTool = Canvas.Tools.First(tool => tool.Name == "Select");
                 }
-                else
-                {
-                    DrawVector(Points.Last(), point);
-                }
             }
             else
             {
-                DrawPoint(point);
                 Points.Add(point);
             }
 
             Canvas.FireInvalidateCanvas();
+        }
+
+        public override Task OnDraw(IRenderer renderer, ISvgDrawingCanvas ws)
+        {
+            // we draw the selection rectangle
+            if (Points.Count != 0)
+            {
+                renderer.Graphics.Save();
+                PolyLinePen.StrokeWidth = 5 / Canvas.ZoomFactor;
+
+                for (int i = 0; i < Points.Count-1; i++)
+                {
+                    var f = Points[i];
+                    var t = Points[i + 1];
+                    renderer.DrawLine(f.X, f.Y, t.X, t.Y, PolyLinePen);
+                }
+
+                var firstPoint = Points[0];
+                var radius = 5f/Canvas.ZoomFactor;
+                renderer.FillCircle(firstPoint.X-(radius/2), firstPoint.Y-(radius/2), radius, PolyCircleBrush);
+            }
+
+            return Task.CompletedTask;
         }
 
         private bool IsClickingOnFirstPoint(PointF tapPoint)
@@ -99,55 +120,30 @@ namespace Svg.Editor.Tools
                    point.Y <= tapPoint.Y + 10 / Canvas.ZoomFactor;
         }
 
-        private void DrawPoint(PointF point)
-        {
-            var circle = new SvgCircle()
-            {
-                CenterX = point.X,
-                CenterY = point.Y,
-                Radius = 5,
-                FillOpacity = 0.75f,
-                StrokeOpacity = 0.75f
-            };
-            circle.CustomAttributes[PolygonTempAttributeKey] = "";
-
-            Canvas.Document.Children.Add(circle);
-        }
-
-        private void DrawVector(PointF start, PointF end)
-        {
-            Points.Add(end);
-
-            var line = new SvgLine()
-            {
-                StartX = start.X,
-                EndX = end.X,
-                StartY = start.Y,
-                EndY = end.Y,
-                StrokeOpacity = 0.5f
-            };
-            line.CustomAttributes[PolygonTempAttributeKey] = "";
-
-            Canvas.Document.Children.Add(line);
-        }
-
         private void DrawPolygon()
         {
-            var points = Points.SelectMany(p => new SvgUnit[] { p.X, p.Y });
-
-            CreatePolygonOverride(points);
+            CreatePolygonOverride(Points);
         }
 
-        protected virtual void CreatePolygonOverride(IEnumerable<SvgUnit> points)
+        protected virtual bool IsValidPolgyon(IList<PointF> points)
+        {
+            if (points.Count < 3)
+                return false;
+
+            return true;
+        }
+
+        protected virtual void CreatePolygonOverride(IEnumerable<PointF> points)
         {
             var collectionPoints = new SvgPointCollection();
-            collectionPoints.AddRange(points);
+            collectionPoints.AddRange(points.SelectMany(p => new SvgUnit[] { p.X, p.Y }));
 
             var polygon = new SvgPolygon()
             {
                 Points = collectionPoints,
                 StrokeWidth = new SvgUnit(SvgUnitType.Pixel, DefaultStrokeWidth),
                 Fill = SvgColourServer.None,
+                Stroke = new SvgColourServer(Color.Create(0,0,0))
             };
             // we do not want the polygon to be filled
             polygon.AddConstraints(NoFillConstraint);
@@ -157,13 +153,14 @@ namespace Svg.Editor.Tools
 
         public override void Reset()
         {
-            var toDelete = Canvas.Document.Children.Where(c => c.CustomAttributes.ContainsKey(PolygonTempAttributeKey))
-                .ToList();
-
-            toDelete.ForEach(item => Canvas.Document.Children.Remove(item));
-
             Points.Clear();
+        }
 
+        public override void Dispose()
+        {
+            PolyCircleBrush.Dispose();
+            PolyLineBrush.Dispose();
+            base.Dispose();
         }
     }
 }

--- a/Svg.Editor.Core/Tools/ShapeToolBase.cs
+++ b/Svg.Editor.Core/Tools/ShapeToolBase.cs
@@ -256,13 +256,6 @@ namespace Svg.Editor.Tools
             DrawCurrentShape(renderer, ws);
         }
 
-        public override async Task Initialize(ISvgDrawingCanvas ws)
-        {
-            await base.Initialize(ws);
-
-            IsActive = false;
-        }
-
         private void UnWatchDocument(SvgDocument svgDocument)
         {
             svgDocument.ChildRemoved -= SvgDocumentOnChildRemoved;

--- a/Svg.Editor.Core/Tools/TextTool.cs
+++ b/Svg.Editor.Core/Tools/TextTool.cs
@@ -77,9 +77,7 @@ namespace Svg.Editor.Tools
 		public override async Task Initialize(ISvgDrawingCanvas ws)
 		{
 			await base.Initialize(ws);
-
-			IsActive = false;
-
+			
 			Canvas.DefaultEditors.Add(async element =>
 			{
 				var svgText = element as SvgTextBase ?? element.Descendants().OfType<SvgTextBase>().FirstOrDefault();

--- a/Svg.Editor.Core/Tools/ToolBase.cs
+++ b/Svg.Editor.Core/Tools/ToolBase.cs
@@ -66,7 +66,7 @@ namespace Svg.Editor.Tools
         public string Name { get; protected set; }
         public ToolUsage ToolUsage { get; protected set; }
         public ToolType ToolType { get; protected set; }
-        public virtual bool IsActive { get; set; } = true;
+        public virtual bool IsActive { get; set; } = false;
         public IEnumerable<IToolCommand> Commands { get; protected set; } = Enumerable.Empty<IToolCommand>();
         /// <summary>
         /// Properties for the tool which can be configured in the designer. Key should be lower-case for consistency.

--- a/Svg.Editor.Forms/Svg.Editor.Forms.csproj
+++ b/Svg.Editor.Forms/Svg.Editor.Forms.csproj
@@ -4,11 +4,14 @@
     <AssemblyName>Svg.Editor.Forms</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetFrameworks>netstandard2.0;MonoAndroid81;Xamarin.iOS10;uap10.0.17763</TargetFrameworks>
-    <Version>2.4.3.3</Version>
+    <Version>2.4.3.4</Version>
     <PackageReleaseNotes>
-	    # 2.4.3.3
-	    - polygon tool
-	    - hit testing basic shapes without fill tests line intersection
+	    # 2.4.3.4
+	    - fixed for plan rendering
+	    - polygon tool improvements (selection rendered on adorner layer)
+		# 2.4.3.3
+		- polygon tool
+		- hit testing basic shapes without fill tests line intersection
 	</PackageReleaseNotes>
   </PropertyGroup>
 
@@ -47,7 +50,7 @@
   
   <ItemGroup>
     <PackageReference Include="SkiaSharp.Views.Forms" Version="1.68.1" />
-    <PackageReference Include="Svg" Version="2.4.3.3" />
+    <PackageReference Include="Svg" Version="2.4.3.4" />
     <PackageReference Include="System.Reactive" Version="4.0.0" />
     <PackageReference Include="Xamarin.Forms" Version="4.1.0.778454" />
   </ItemGroup>

--- a/Svg.Editor.Sample.Forms/Svg.Editor.Sample.Forms.iOS/project.json
+++ b/Svg.Editor.Sample.Forms/Svg.Editor.Sample.Forms.iOS/project.json
@@ -3,7 +3,7 @@
     "Acr.UserDialogs": "6.3.9",
     "SkiaSharp": "1.68.1",
     "SkiaSharp.Views.Forms": "1.68.1",
-    "Svg": "2.4.3.3",
+    "Svg": "2.4.3.4",
     "System.Reactive": "3.1.1",
     "System.Reactive.Core": "3.1.1",
     "System.Reactive.Interfaces": "3.1.1",

--- a/Svg.Editor.Sample.Forms/Svg.Editor.Sample.Forms/Svg.Editor.Sample.Forms.csproj
+++ b/Svg.Editor.Sample.Forms/Svg.Editor.Sample.Forms/Svg.Editor.Sample.Forms.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Acr.UserDialogs" Version="6.3.9" />
     <PackageReference Include="SkiaSharp.Views.Forms" Version="1.68.1" />
-    <PackageReference Include="Svg" Version="2.4.3.3" />
+    <PackageReference Include="Svg" Version="2.4.3.4" />
     <PackageReference Include="System.Reactive" Version="4.0.0" />
     <PackageReference Include="Xam.Plugin.Media" Version="4.0.1.5" />
     <PackageReference Include="Xamarin.Forms" Version="4.1.0.778454" />

--- a/Svg.Editor.Sample.Forms/Svg.Editor.Sample.Forms/Tools/AddItemTool.cs
+++ b/Svg.Editor.Sample.Forms/Svg.Editor.Sample.Forms/Tools/AddItemTool.cs
@@ -10,14 +10,7 @@ namespace Svg.Editor.Sample.Forms.Tools
 		public AddItemTool() : base("Add item", null)
 		{
 		}
-
-        public override async Task Initialize(ISvgDrawingCanvas ws)
-        {
-            await base.Initialize(ws);
-
-            IsActive = false;
-        }
-
+		
 		protected override async Task OnLongPress(LongPressGesture longPress)
 		{
 			await base.OnLongPress(longPress);

--- a/Svg.Editor.Views/Svg.Editor.Views.csproj
+++ b/Svg.Editor.Views/Svg.Editor.Views.csproj
@@ -2,11 +2,14 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;MonoAndroid81;Xamarin.iOS10;uap10.0.17763</TargetFrameworks>
-    <Version>2.4.3.3</Version>
+    <Version>2.4.3.4</Version>
     <PackageReleaseNotes>
-	    # 2.4.3.3
+	    # 2.4.3.4
+	    - fixed for plan rendering
+	    - polygon tool improvements (selection rendered on adorner layer)
+		# 2.4.3.3
 		- polygon tool
-	    - hit testing basic shapes without fill tests line intersection
+		- hit testing basic shapes without fill tests line intersection
 	</PackageReleaseNotes>
   </PropertyGroup>
 

--- a/Svg/Platform/SkiaLinearGradientBrush.cs
+++ b/Svg/Platform/SkiaLinearGradientBrush.cs
@@ -95,6 +95,7 @@ namespace Svg.Platform
             _shader = SKShader.CreateLinearGradient(new SKPoint(Start.X, Start.Y), new SKPoint(End.X, End.Y), colors, positions, tileMode);
             
             paint.Shader = _shader;
+            paint.IsAntialias = true;
             return paint;
         }
 

--- a/Svg/Platform/SkiaRadialGradientBrush.cs
+++ b/Svg/Platform/SkiaRadialGradientBrush.cs
@@ -91,6 +91,8 @@ namespace Svg.Platform
             _shader = SKShader.CreateRadialGradient(new SKPoint(Center.X, Center.Y), Radius, colors, positions, tileMode);
 
             paint.Shader = _shader;
+            paint.IsAntialias = true;
+
             return paint;
         }
 

--- a/Svg/Platform/SkiaSolidBrush.cs
+++ b/Svg/Platform/SkiaSolidBrush.cs
@@ -24,6 +24,7 @@ namespace Svg.Platform
 
             var paint = new SKPaint();
             paint.Color = _color;
+            paint.IsAntialias = true;
             return paint;
         }
     }

--- a/Svg/Platform/SkiaTextRenderer.cs
+++ b/Svg/Platform/SkiaTextRenderer.cs
@@ -37,10 +37,15 @@ namespace Svg.Platform
             if (txt.Stroke != null)
             {
                 var brush = txt.Stroke.GetBrush(txt, renderer, 1f);
+                ((SkiaBrushBase)brush).Paint.Typeface = SKTypeface.FromFamilyName(txt.FontFamily, txt.FontWeight.ToSkFontStyleWeight(), SKFontStyleWidth.Normal, txt.FontStyle.ToSkFontStyleSlant());
                 using (var pen = (SkiaPen)SvgEngine.Factory.CreatePen(brush, txt.StrokeWidth.Value))
                 {
                     pen.TextSize = txt.FontSize.Value;
                     pen.TextAlign = FromAnchor(txt.TextAnchor);
+
+                    byte strokeOpacity = (byte)(pen.Paint.Color.Alpha * txt.StrokeOpacity);
+                    pen.Paint.Color = new SKColor(pen.Paint.Color.Red, pen.Paint.Color.Green, pen.Paint.Color.Blue,
+                        strokeOpacity);
 
                     var x = txt.X.Any() ? txt.X.FirstOrDefault().Value : 0f;
                     var y = txt.Y.Any() ? txt.Y.FirstOrDefault().Value : 0f;
@@ -57,10 +62,18 @@ namespace Svg.Platform
             if (txt.Fill != null)
             {
                 var brush = txt.Fill.GetBrush(txt, renderer, 1f);
+                
+                var paint = ((SkiaBrushBase)brush).Paint;
+                paint.Typeface = SKTypeface.FromFamilyName(txt.FontFamily, txt.FontWeight.ToSkFontStyleWeight(), SKFontStyleWidth.Normal, txt.FontStyle.ToSkFontStyleSlant());
+
                 using (var pen = (SkiaPen)SvgEngine.Factory.CreatePen(brush, 0f))
                 {
                     pen.TextSize = txt.FontSize.Value;
                     pen.TextAlign = FromAnchor(txt.TextAnchor);
+
+                    byte fillOpacity = (byte)(pen.Paint.Color.Alpha * txt.FillOpacity);
+                    pen.Paint.Color = new SKColor(pen.Paint.Color.Red, pen.Paint.Color.Green, pen.Paint.Color.Blue,
+                        fillOpacity);
 
                     var x = txt.X.Any() ? txt.X.FirstOrDefault().Value : 0f;
                     var y = txt.Y.Any() ? txt.Y.FirstOrDefault().Value : 0f;
@@ -200,6 +213,34 @@ namespace Svg.Platform
                 default:
                     return SKTextAlign.Left;
             }
+        }
+    }
+
+    internal static class FontWeightExtensions
+    {
+        internal static SKFontStyleWeight ToSkFontStyleWeight(this SvgFontWeight style)
+        {
+            return style switch
+            {
+                SvgFontWeight.Normal => SKFontStyleWeight.Normal,
+                SvgFontWeight.Lighter => SKFontStyleWeight.Light,
+                SvgFontWeight.Bold => SKFontStyleWeight.Bold,
+                SvgFontWeight.Bolder => SKFontStyleWeight.ExtraBold,
+                SvgFontWeight.W600 => SKFontStyleWeight.Bold,
+                SvgFontWeight.W800 => SKFontStyleWeight.ExtraBold,
+                SvgFontWeight.W900 => SKFontStyleWeight.ExtraBold,
+                _ => SKFontStyleWeight.Normal
+            };
+        }
+        internal static SKFontStyleSlant ToSkFontStyleSlant(this SvgFontStyle style)
+        {
+            return style switch
+            {
+                SvgFontStyle.Normal => SKFontStyleSlant.Upright,
+                SvgFontStyle.Italic => SKFontStyleSlant.Italic,
+                SvgFontStyle.Oblique => SKFontStyleSlant.Oblique,
+                _ => SKFontStyleSlant.Upright
+            };
         }
     }
 }

--- a/Svg/Platform/SkiaTextureBrush.cs
+++ b/Svg/Platform/SkiaTextureBrush.cs
@@ -36,6 +36,7 @@ namespace Svg.Platform
             _shader = SKShader.CreateBitmap(_image.Image, SKShaderTileMode.Clamp, SKShaderTileMode.Clamp);
             
             paint.Shader = _shader;
+            paint.IsAntialias = true;
             return paint;
         }
     }

--- a/Svg/Svg.csproj
+++ b/Svg/Svg.csproj
@@ -3,10 +3,16 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;MonoAndroid81;Xamarin.iOS10;uap10.0.18362;net462</TargetFrameworks>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-    <Version>2.4.3.3</Version>
+    <Version>2.4.3.4</Version>
     <Authors>gentledpp,bruzkovsky</Authors>
     <Company>Opti-Q GmbH</Company>
-    <PackageReleaseNotes>netstandard multiplatform</PackageReleaseNotes>
+    <PackageReleaseNotes>
+		# 2.4.3.4
+		- antialiasing on by default
+
+		# 2.4.3.3
+		netstandard multiplatform
+	</PackageReleaseNotes>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/Svg/SvgElementFactory.cs
+++ b/Svg/SvgElementFactory.cs
@@ -147,7 +147,7 @@ namespace Svg
                         {
                             if (!Regex.IsMatch(decl.Name, @"^(:|[A-Z]|_|[a-z]|[\u00C0-\u00D6]|[\u00D8-\u00F6]|[\u00F8-\u02FF]|[\u0370-\u037D]|[\u037F-\u1FFF]|[\u200C-\u200D]|[\u2070-\u218F]|[\u2C00-\u2FEF]|[\u3001-\uD7FF]|[\uF900-\uFDCF]|[\uFDF0-\uFFFD])"))
                                 continue;
-                            element.AddStyle(decl.Name, decl.Term.ToString(), SvgElement.StyleSpecificity_InlineStyle);
+                            element.AddStyle(decl.Name, decl.Term?.ToString(), SvgElement.StyleSpecificity_InlineStyle);
                         }
                     }
                 }


### PR DESCRIPTION
- added UT for PanTool
- PolygonTool uses IEnumerable<PointF> for creating new polygons
- color tool does not set fill or stroke in case fill/stroke is "none" or "null"
- enabled antiaaliasing in basic brush
- SkiaTextRenderer supports opacity, font family, fontweight and fontstyle
- added simple polygon validation
- refactored polygontool to draw on adorner canvas (instead of adding/removing utility lines/circles to the svgdocument)
- fixed possible NRE in SvgElementFactory
- fixed NRE in PolygonTool, and tools self-deactivating...