### PR TITLE
#9299 - UWP - recognize gestures correctly on second screen too

### DIFF
--- a/Svg.Editor.Core/Svg.Editor.Core.csproj
+++ b/Svg.Editor.Core/Svg.Editor.Core.csproj
@@ -4,14 +4,16 @@
     <AssemblyName>Svg.Editor</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>2.4.3.4</Version>
+    <Version>2.4.3.5</Version>
     <PackageReleaseNotes>
-        # 2.4.3.4
-        - fixed for plan rendering
-        - polygon tool improvements (selection rendered on adorner layer)
-	    # 2.4.3.3
-	    - polygon tool
-	    - hit testing basic shapes without fill tests line intersection
+        # 2.4.3.5
+        - fixed UWP gesture recognizer
+		# 2.4.3.4
+		- fixed for plan rendering
+		- polygon tool improvements (selection rendered on adorner layer)
+		# 2.4.3.3
+		- polygon tool
+		- hit testing basic shapes without fill tests line intersection
 	</PackageReleaseNotes>
   </PropertyGroup>
 

--- a/Svg.Editor.Forms/Svg.Editor.Forms.csproj
+++ b/Svg.Editor.Forms/Svg.Editor.Forms.csproj
@@ -4,11 +4,13 @@
     <AssemblyName>Svg.Editor.Forms</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetFrameworks>netstandard2.0;MonoAndroid81;Xamarin.iOS10;uap10.0.17763</TargetFrameworks>
-    <Version>2.4.3.4</Version>
+    <Version>2.4.3.5</Version>
     <PackageReleaseNotes>
-	    # 2.4.3.4
-	    - fixed for plan rendering
-	    - polygon tool improvements (selection rendered on adorner layer)
+        # 2.4.3.5
+        - fixed UWP gesture recognizer
+		# 2.4.3.4
+		- fixed for plan rendering
+		- polygon tool improvements (selection rendered on adorner layer)
 		# 2.4.3.3
 		- polygon tool
 		- hit testing basic shapes without fill tests line intersection

--- a/Svg.Editor.Views/Platforms/UniversalWindows/UwpGestureRecognizer.cs
+++ b/Svg.Editor.Views/Platforms/UniversalWindows/UwpGestureRecognizer.cs
@@ -7,6 +7,7 @@ using Windows.UI.Input;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
+using SkiaSharp.Views.UWP;
 using Svg.Editor.Events;
 using Svg.Editor.Gestures;
 using Svg.Editor.Interfaces;
@@ -95,8 +96,14 @@ namespace Svg.Editor.Views.UWP
 
         private void ElementRightTapped(object sender, RightTappedRoutedEventArgs args)
         {
+            var dpi = 1.0;
+            if (_element is SKXamlCanvas c)
+            {
+                dpi = c.Dpi;
+            }
             var position = args.GetPosition(_element);
-            _gesturesSubject.OnNext(new LongPressGesture(PointF.Create((float) position.X, (float) position.Y)));
+            _gesturesSubject.OnNext(
+                new LongPressGesture(PointF.Create((float)(position.X * dpi), (float)(position.Y * dpi))));
         }
 
         private void ElementOnPointerWheelChanged(object sender, PointerRoutedEventArgs args)
@@ -109,14 +116,26 @@ namespace Svg.Editor.Views.UWP
 
         private void ElementOnDoubleTapped(object sender, DoubleTappedRoutedEventArgs args)
         {
+            var dpi = 1.0;
+            if (_element is SKXamlCanvas c)
+            {
+                dpi = c.Dpi;
+            }
             var position = args.GetPosition(_element);
-            _gesturesSubject.OnNext(new DoubleTapGesture(PointF.Create((float) position.X, (float) position.Y)));
+            _gesturesSubject.OnNext(
+                new DoubleTapGesture(PointF.Create((float)(position.X * dpi), (float)(position.Y * dpi))));
         }
 
         private void ElementOnTapped(object sender, TappedRoutedEventArgs args)
         {
+            var dpi = 1.0;
+            if (_element is SKXamlCanvas c)
+            {
+                dpi = c.Dpi;
+            }
             var position = args.GetPosition(_element);
-            _gesturesSubject.OnNext(new TapGesture(PointF.Create((float) position.X, (float) position.Y)));
+            _gesturesSubject.OnNext(
+                new TapGesture(PointF.Create((float)(position.X * dpi), (float)(position.Y * dpi))));
         }
 
         public void InitializeTransforms()
@@ -207,7 +226,14 @@ namespace Svg.Editor.Views.UWP
         // that a manipulation is in progress
         private void OnManipulationStarted(object sender, ManipulationStartedEventArgs e)
         {
-            _gesturesSubject.OnNext(DragGesture.Enter(PointF.Create((float) e.Position.X, (float) e.Position.Y)));
+            var dpi = 1.0;
+            if (_element is SKXamlCanvas c)
+            {
+                dpi = c.Dpi;
+            }
+
+            _gesturesSubject.OnNext(
+                DragGesture.Enter(PointF.Create((float)(e.Position.X * dpi), (float)(e.Position.Y * dpi))));
         }
 
         // Process the change resulting from a manipulation

--- a/Svg.Editor.Views/Svg.Editor.Views.csproj
+++ b/Svg.Editor.Views/Svg.Editor.Views.csproj
@@ -2,11 +2,13 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;MonoAndroid81;Xamarin.iOS10;uap10.0.17763</TargetFrameworks>
-    <Version>2.4.3.4</Version>
+    <Version>2.4.3.5</Version>
     <PackageReleaseNotes>
-	    # 2.4.3.4
-	    - fixed for plan rendering
-	    - polygon tool improvements (selection rendered on adorner layer)
+        # 2.4.3.5
+        - fixed UWP gesture recognizer
+		# 2.4.3.4
+		- fixed for plan rendering
+		- polygon tool improvements (selection rendered on adorner layer)
 		# 2.4.3.3
 		- polygon tool
 		- hit testing basic shapes without fill tests line intersection


### PR DESCRIPTION
fixed:
- misplaced pins
- selection bug - on the second screen selection didn't work because of the same issue