### PR TITLE
#11514 - Svg Plan throws no instance of an object error on drawing pa…

### DIFF
--- a/Svg.Editor.Core/Svg.Editor.Core.csproj
+++ b/Svg.Editor.Core/Svg.Editor.Core.csproj
@@ -105,7 +105,7 @@
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
 		<PackageReference Include="SkiaSharp" Version="1.68.1" />
-		<PackageReference Include="Svg" Version="2.4.4.9" />
+		<PackageReference Include="Svg" Version="2.4.4.10" />
 		<PackageReference Include="System.Reactive" Version="4.0.0" />
 		<PackageReference Include="Xamarin.Forms" Version="4.1.0.778454" />
 	</ItemGroup>

--- a/Svg.Editor.Core/Svg.Editor.Core.csproj
+++ b/Svg.Editor.Core/Svg.Editor.Core.csproj
@@ -4,9 +4,11 @@
     <AssemblyName>Svg.Editor</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetFramework>netstandard2.0</TargetFramework>
-	  <Version>2.4.4.9</Version>
+	  <Version>2.4.4.10</Version>
 	  <LangVersion>latest</LangVersion>
 	  <PackageReleaseNotes>
+		  #2.4.4.10
+		- fix: Svg Plan throws no instance of an object error on drawing pathsegment
 		  #2.4.4.9
 		  - fix: rendering Drawing Clippaths with canvas transformation
 		  #2.4.4.8

--- a/Svg.Editor.Forms/Svg.Editor.Forms.csproj
+++ b/Svg.Editor.Forms/Svg.Editor.Forms.csproj
@@ -4,9 +4,11 @@
     <AssemblyName>Svg.Editor.Forms</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetFrameworks>netstandard2.0;MonoAndroid81;Xamarin.iOS10;uap10.0.17763</TargetFrameworks>
-	  <Version>2.4.4.9</Version>
+	  <Version>2.4.4.10</Version>
 	  <LangVersion>latest</LangVersion>
 	  <PackageReleaseNotes>
+		  #2.4.4.10
+		  - fix: Svg Plan throws no instance of an object error on drawing pathsegment
 		  #2.4.4.9
 		  - fix: rendering Drawing Clippaths with canvas transformation
 		  #2.4.4.8

--- a/Svg.Editor.Forms/Svg.Editor.Forms.csproj
+++ b/Svg.Editor.Forms/Svg.Editor.Forms.csproj
@@ -88,7 +88,7 @@
   
   <ItemGroup>
     <PackageReference Include="SkiaSharp.Views.Forms" Version="1.68.1" />
-    <PackageReference Include="Svg" Version="2.4.4.9" />
+    <PackageReference Include="Svg" Version="2.4.4.10" />
     <PackageReference Include="System.Reactive" Version="4.0.0" />
     <PackageReference Include="Xamarin.Forms" Version="4.1.0.778454" />
   </ItemGroup>

--- a/Svg.Editor.Sample.Forms/Svg.Editor.Sample.Forms.iOS/project.json
+++ b/Svg.Editor.Sample.Forms/Svg.Editor.Sample.Forms.iOS/project.json
@@ -3,7 +3,7 @@
     "Acr.UserDialogs": "6.3.9",
     "SkiaSharp": "1.68.1",
     "SkiaSharp.Views.Forms": "1.68.1",
-    "Svg": "2.4.4.9",
+    "Svg": "2.4.4.10",
     "System.Reactive": "3.1.1",
     "System.Reactive.Core": "3.1.1",
     "System.Reactive.Interfaces": "3.1.1",

--- a/Svg.Editor.Sample.Forms/Svg.Editor.Sample.Forms/Svg.Editor.Sample.Forms.csproj
+++ b/Svg.Editor.Sample.Forms/Svg.Editor.Sample.Forms/Svg.Editor.Sample.Forms.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Acr.UserDialogs" Version="6.3.9" />
     <PackageReference Include="SkiaSharp.Views.Forms" Version="1.68.1" />
-    <PackageReference Include="Svg" Version="2.4.4.9" />
+    <PackageReference Include="Svg" Version="2.4.4.10" />
     <PackageReference Include="System.Reactive" Version="4.0.0" />
     <PackageReference Include="Xam.Plugin.Media" Version="4.0.1.5" />
     <PackageReference Include="Xamarin.Forms" Version="4.1.0.778454" />

--- a/Svg.Editor.Views/Svg.Editor.Views.csproj
+++ b/Svg.Editor.Views/Svg.Editor.Views.csproj
@@ -2,9 +2,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;MonoAndroid81;Xamarin.iOS10;uap10.0.17763</TargetFrameworks>
-	  <Version>2.4.4.9</Version>
+	  <Version>2.4.4.10</Version>
 	  <LangVersion>latest</LangVersion>
 	  <PackageReleaseNotes>
+		  #2.4.4.10
+		  - fix: Svg Plan throws no instance of an object error on drawing pathsegment
 		  #2.4.4.9
 		  - fix: rendering Drawing Clippaths with canvas transformation
 		  #2.4.4.8

--- a/Svg.Tests.Win/Assets/ClipPathBounds.svg
+++ b/Svg.Tests.Win/Assets/ClipPathBounds.svg
@@ -1,0 +1,13 @@
+﻿<svg width="200" height="100" xmlns="http://www.w3.org/2000/svg">
+	<defs>
+		<clipPath id="cut-bottom">
+			<rect x="0" y="0" width="200" height="50" />
+		</clipPath>
+	</defs>
+	<g clip-path="url(#cut-bottom)" >
+		<rect width="20000" height="100000" x="10" y="10" rx="20" ry="20" fill="blue" />
+	</g>
+	<g clip-path="url(#cut-bottom)" >
+		<rect width="20" height="10" x="10" y="10" rx="20" ry="20" fill="blue" />
+	</g>
+</svg>

--- a/Svg.Tests.Win/Assets/plan_iss.svg
+++ b/Svg.Tests.Win/Assets/plan_iss.svg
@@ -1,0 +1,3 @@
+<svg height="210" width="400" xmlns="http://www.w3.org/2000/svg">
+	<path d="M150 5 L75 200 L225 200Z L 150 29" style="fill:none;stroke:green;stroke-width:3" />
+</svg>

--- a/Svg.Tests.Win/Svg.Tests.Win.csproj
+++ b/Svg.Tests.Win/Svg.Tests.Win.csproj
@@ -102,6 +102,9 @@
     <Content Include="Assets\clip_path.svg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Assets\plan_iss.svg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Assets\testBosPlan.svg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/Svg.Tests.Win/Svg.Tests.Win.csproj
+++ b/Svg.Tests.Win/Svg.Tests.Win.csproj
@@ -85,6 +85,7 @@
     <Compile Include="SvgHitTest_Path.cs" />
     <Compile Include="SvgRendererTests.cs" />
     <Compile Include="SvgTextTests.cs" />
+    <Compile Include="SvgVisualElementsExtensionsTests.cs" />
     <Compile Include="TestHelper.cs" />
     <Compile Include="TestSkPaint.cs" />
     <Compile Include="WebRequestSvcTests.cs" />
@@ -100,6 +101,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Assets\clip_path.svg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\ClipPathBounds.svg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Assets\plan_iss.svg">

--- a/Svg.Tests.Win/SvgClipPathTest.cs
+++ b/Svg.Tests.Win/SvgClipPathTest.cs
@@ -68,4 +68,18 @@ public class SvgClipPathTest
         c.AssertAreSimilar(97f, svgPath);
 
     }
+
+    [Test]
+    public void WhenGettingCliPathBounds_BasedOnClipPathsChildren_GetBounds()
+    {
+        // Arrange
+        var svgPath = "ClipPathBounds.svg";
+
+        var svgDoc = SvgDocument.Open<SvgDocument>("Assets\\" + svgPath);
+
+        var clip = svgDoc.Children.First().Children.OfType<SvgClipPath>().First();
+
+        Assert.AreEqual(clip.Bounds.Width, 200);
+        Assert.AreEqual(clip.Bounds.Height, 50);
+    }
 }

--- a/Svg.Tests.Win/SvgDocumentTest.cs
+++ b/Svg.Tests.Win/SvgDocumentTest.cs
@@ -156,5 +156,17 @@ namespace Svg.Tests.Win
             actualFontFamily[0].Should().Be("sans-serif");
             actualFontFamily[1].Should().Be("");
         }
+
+        [Test]
+        public void WhenGettingDocumentBounds_AndChildrenHaveClipPath_GetBoundsBasedOnChildrenWithClipPath()
+        {
+            // Arrange
+            var svgPath = "ClipPathBounds.svg";
+
+            var svgDoc = SvgDocument.Open<SvgDocument>("Assets\\" + svgPath);
+
+            Assert.AreEqual(200, svgDoc.CalculateDocumentBounds().Width);
+            Assert.AreEqual(50, svgDoc.CalculateDocumentBounds().Height);
+        }
     }
 }

--- a/Svg.Tests.Win/SvgRendererTests.cs
+++ b/Svg.Tests.Win/SvgRendererTests.cs
@@ -328,5 +328,26 @@ namespace Svg.Tests.Win
 
             public Guid GetAttributeChangeToken() => AttributeChangeToken;
         }
+
+
+        [Test]
+        public void When_PathSegment_Is_After_ClosePathSegmentZ_Render_Svg()
+        {
+            // Arrange
+            var pngPath = "test_iss_plan.png";
+            var svgPath = "plan_iss.svg";
+
+            // Act
+            using var pngBitmap = TestHelper.GetBitmap(pngPath);
+
+            using var svgBitmap = TestHelper.RenderSvg(svgPath, pngBitmap.Width, pngBitmap.Height);
+
+            // Assert
+            using var c = TestHelper.ImageCompare(svgBitmap, pngBitmap);
+
+
+            c.AssertAreSimilar(97f, svgPath);
+
+        }
     }
 }

--- a/Svg.Tests.Win/SvgVisualElementsExtensionsTests.cs
+++ b/Svg.Tests.Win/SvgVisualElementsExtensionsTests.cs
@@ -1,0 +1,51 @@
+﻿using System.Linq;
+using NUnit.Framework;
+using Svg.Editor.Tests;
+
+namespace Svg.Tests.Win;
+
+[TestFixture]
+public class SvgVisualElementsExtensionsTests
+{
+    [SetUp]
+    public void SetUp()
+    {
+        SvgPlatform.Init();
+    }
+
+    [Test]
+    public void WhenGettingBoundsFromVisualElement_WithClipPathSmallerThanElement_GetClipPathBound()
+    {
+        // Arrange
+        var svgPath = "ClipPathBounds.svg";
+
+        var svgDoc = SvgDocument.Open<SvgDocument>("Assets\\" + svgPath);
+        var rectangle = svgDoc.Children[1].Children.OfType<SvgRectangle>().FirstOrDefault();
+
+
+        Assert.IsNotNull(rectangle);
+        Assert.AreEqual(20000, (int)rectangle.Width);
+        Assert.AreEqual(100000, (int)rectangle.Height);
+        Assert.AreEqual(200, rectangle.GetBounds().Width);
+        Assert.AreEqual(50, rectangle.GetBounds().Height);
+        
+    }
+
+    [Test]
+    public void WhenGettingBoundsFromVisualElement_WithClipPathBiggerThanElement_GetElementBound()
+    {
+        // Arrange
+        var svgPath = "ClipPathBounds.svg";
+
+        var svgDoc = SvgDocument.Open<SvgDocument>("Assets\\" + svgPath);
+        var rectangle = svgDoc.Children[2].Children.OfType<SvgRectangle>().FirstOrDefault();
+
+
+        Assert.IsNotNull(rectangle);
+        Assert.AreEqual(20, (int)rectangle.Width);
+        Assert.AreEqual(10, (int)rectangle.Height);
+        Assert.AreEqual(20, rectangle.GetBounds().Width);
+        Assert.AreEqual(10, rectangle.GetBounds().Height);
+        
+    }
+}

--- a/Svg/Basic Shapes/SvgCircle.cs
+++ b/Svg/Basic Shapes/SvgCircle.cs
@@ -1,3 +1,4 @@
+using Svg.Basic_Shapes;
 using Svg.Interfaces;
 
 namespace Svg
@@ -74,7 +75,7 @@ namespace Svg
 
         public override RectangleF GetBounds()
         {
-            return this.Path(null).GetBounds();
+            return this.GetBoundsWithClipPaths();
         }
 
         /// <summary>

--- a/Svg/Basic Shapes/SvgEllipse.cs
+++ b/Svg/Basic Shapes/SvgEllipse.cs
@@ -1,4 +1,5 @@
 
+using Svg.Basic_Shapes;
 using Svg.Interfaces;
 
 namespace Svg
@@ -94,7 +95,7 @@ namespace Svg
 
         public override RectangleF GetBounds()
         {
-                return this.Path(null).GetBounds();
+            return this.GetBoundsWithClipPaths();
         }
 
         /// <summary>

--- a/Svg/Basic Shapes/SvgImage.cs
+++ b/Svg/Basic Shapes/SvgImage.cs
@@ -97,26 +97,37 @@ namespace Svg
 
         public override RectangleF GetBounds()
         {
+            if (this.ClipPath != null)
+            {
+                SvgClipPath clipPath = this.OwnerDocument.GetElementById<SvgClipPath>(this.ClipPath.OriginalString);
+                if (clipPath != null)
+                {
+                    return clipPath.Bounds;
+                }
+            }
+
             // if a width/height is set explicitly, use that
-                if (!Width.IsNone && !Width.IsEmpty && !Height.IsNone && !Height.IsEmpty)
-                    return RectangleF.Create(Location.ToDeviceValue(null, this),
-                        SizeF.Create(Width.ToDeviceValue(null, UnitRenderingType.Horizontal, this),
-                            Height.ToDeviceValue(null, UnitRenderingType.Vertical, this)));
-
-                var bmp = _img as Image;
-                var svg = _img as SvgFragment;
-
-                if (bmp != null)
-                {
-                    return RectangleF.Create(Location.ToDeviceValue(null, this), SizeF.Create(bmp.Width, bmp.Height));
-                }
-                if (svg != null)
-                {
-                    return RectangleF.Create(Location.ToDeviceValue(null, this), svg.Bounds.Size);
-                }
+            if (!Width.IsNone && !Width.IsEmpty && !Height.IsNone && !Height.IsEmpty)
                 return RectangleF.Create(Location.ToDeviceValue(null, this),
-                                        SizeF.Create(Width.ToDeviceValue(null, UnitRenderingType.Horizontal, this),
-                                                  Height.ToDeviceValue(null, UnitRenderingType.Vertical, this)));
+                    SizeF.Create(Width.ToDeviceValue(null, UnitRenderingType.Horizontal, this),
+                        Height.ToDeviceValue(null, UnitRenderingType.Vertical, this)));
+
+            var bmp = _img as Image;
+            var svg = _img as SvgFragment;
+
+            if (bmp != null)
+            {
+                return RectangleF.Create(Location.ToDeviceValue(null, this), SizeF.Create(bmp.Width, bmp.Height));
+            }
+
+            if (svg != null)
+            {
+                return RectangleF.Create(Location.ToDeviceValue(null, this), svg.Bounds.Size);
+            }
+
+            return RectangleF.Create(Location.ToDeviceValue(null, this),
+                SizeF.Create(Width.ToDeviceValue(null, UnitRenderingType.Horizontal, this),
+                    Height.ToDeviceValue(null, UnitRenderingType.Vertical, this)));
         }
 
         /// <summary>

--- a/Svg/Basic Shapes/SvgLine.cs
+++ b/Svg/Basic Shapes/SvgLine.cs
@@ -1,5 +1,5 @@
 using System;
-
+using Svg.Basic_Shapes;
 using Svg.Interfaces;
 
 namespace Svg
@@ -169,9 +169,9 @@ namespace Svg
 
         public override RectangleF GetBounds()
         {
-                return this.Path(null).GetBounds();
+            return this.GetBoundsWithClipPaths();
         }
-        
+
         protected internal override bool IntersectsWith(RectangleF rectangle, Matrix transform, int maxRecursion)
         {
             var start = PointF.Create(this.StartX, this.StartY);

--- a/Svg/Basic Shapes/SvgPolygon.cs
+++ b/Svg/Basic Shapes/SvgPolygon.cs
@@ -1,3 +1,4 @@
+using Svg.Basic_Shapes;
 using Svg.Interfaces;
 using System;
 using System.Collections.Generic;
@@ -142,9 +143,9 @@ namespace Svg
 
         public override RectangleF GetBounds()
         {
-            return this.Path(null).GetBounds();
+            return this.GetBoundsWithClipPaths();
         }
-        
+
         public override SvgElement DeepCopy()
         {
             return DeepCopy<SvgPolygon>();

--- a/Svg/Basic Shapes/SvgRectangle.cs
+++ b/Svg/Basic Shapes/SvgRectangle.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Svg.Basic_Shapes;
 using Svg.Interfaces;
 
 namespace Svg
@@ -173,7 +174,7 @@ namespace Svg
 
         public override RectangleF GetBounds()
         {
-                return Path(null).GetBounds();
+            return this.GetBoundsWithClipPaths();
         }
 
         /// <summary>

--- a/Svg/Basic Shapes/SvgVisualElement.cs
+++ b/Svg/Basic Shapes/SvgVisualElement.cs
@@ -49,6 +49,16 @@ namespace Svg
                     {
                         // First it should check if rectangle is empty or it will return the wrong Bounds.
                         // This is because when the Rectangle is Empty, the Union method adds as if the first values where X=0, Y=0
+                        if (this.ClipPath != null)
+                        {
+                            SvgClipPath clipPath =
+                                this.OwnerDocument.GetElementById<SvgClipPath>(this.ClipPath.ToString());
+                            if (clipPath != null){
+                                r = clipPath.Bounds;
+                                return r;
+                            }
+                        }
+
                         if (r.IsEmpty)
                         {
                             r = ((SvgVisualElement)c).Bounds;
@@ -113,7 +123,7 @@ namespace Svg
         public RectangleF GetBoundingBox(Matrix transform = null)
         {
             var pts = GetTransformedPoints(transform);
-            
+
             return RectangleF.FromPoints(pts);
         }
         

--- a/Svg/Basic Shapes/SvgVisualElementExtensions.cs
+++ b/Svg/Basic Shapes/SvgVisualElementExtensions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Svg.Interfaces;
+
+namespace Svg.Basic_Shapes
+{
+    public static class SvgVisualElementExtensions
+    {
+        public static RectangleF GetBoundsWithClipPaths(this SvgVisualElement element)
+        {
+            var bounds = element.Path(null).GetBounds();
+            if (element.ClipPath != null)
+            {
+                SvgClipPath clipPath = element.OwnerDocument.GetElementById<SvgClipPath>(element.ClipPath.OriginalString);
+                if (clipPath != null && (clipPath.Bounds.Width < bounds.Width || clipPath.Bounds.Height < bounds.Width))
+                {
+                    return clipPath.Bounds;
+                }
+            }
+
+            return bounds;
+        }
+    }
+}

--- a/Svg/Clipping and Masking/SvgClipPath.cs
+++ b/Svg/Clipping and Masking/SvgClipPath.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
+using Svg.Interfaces;
 using Svg.Transforms;
 
 namespace Svg
@@ -33,6 +35,8 @@ namespace Svg
         {
             this.ClipPathUnits = SvgCoordinateUnits.Inherit;
         }
+
+        public RectangleF Bounds => CalculateClipBounds();
 
         /// <summary>
         /// Gets this <see cref="SvgClipPath"/>'s region to be used as a clipping region.
@@ -71,6 +75,32 @@ namespace Svg
         public Region GetClipRegion(SvgVisualElement owner)
         {
             return new Region(GetClipRegionPath(owner));
+        }
+
+        private RectangleF CalculateClipBounds()
+        {
+            RectangleF documentSize = null;
+
+            foreach (var element in Children.OfType<SvgVisualElement>())
+            {
+                var bounds = element.GetBoundingBox();
+
+                if (documentSize == null)
+                    documentSize = bounds;
+                else
+                    documentSize = documentSize.UnionAndCopy(bounds);
+            }
+
+            documentSize ??= RectangleF.Create();
+
+            if (!Transforms.Any())
+                return documentSize;
+
+            var m = Matrix.Create();
+            foreach (var transform in Transforms)
+                transform.ApplyTo(m);
+
+            return m.TransformRectangle(documentSize);
         }
 
         /// <summary>

--- a/Svg/Paths/SvgLineSegment.cs
+++ b/Svg/Paths/SvgLineSegment.cs
@@ -16,6 +16,8 @@ namespace Svg.Pathing
 
         public override void AddToPath(GraphicsPath graphicsPath)
         {
+            if (this.Start == null)
+                this.Start = graphicsPath.PathPoints[0];
             graphicsPath.AddLine(this.Start, this.End);
         }
         

--- a/Svg/Paths/SvgPath.cs
+++ b/Svg/Paths/SvgPath.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Svg.Basic_Shapes;
 using Svg.Interfaces;
 using Svg.Pathing;
 using Svg.Transforms;
@@ -115,7 +116,7 @@ namespace Svg
 
         public override RectangleF GetBounds()
         {
-            return this.Path(null).GetBounds();
+            return this.GetBoundsWithClipPaths();
         }
 
         /// <summary>

--- a/Svg/Platform/SkiaGraphicsPath.cs
+++ b/Svg/Platform/SkiaGraphicsPath.cs
@@ -141,7 +141,7 @@ namespace Svg.Platform
                 _pathTypes.Add(0); // start of a figure ??
             }
         }
-        
+
         public void AddLine(PointF start, PointF end)
         {
             _bounds = null;

--- a/Svg/Svg.csproj
+++ b/Svg/Svg.csproj
@@ -3,25 +3,27 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;MonoAndroid81;Xamarin.iOS10;uap10.0.18362;net462</TargetFrameworks>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-    <Version>2.4.4.9</Version>
+    <Version>2.4.4.10</Version>
     <Authors>gentledpp,bruzkovsky</Authors>
     <Company>Opti-Q GmbH</Company>
     <PackageReleaseNotes>
-	    #2.4.4.9
-	    - fix: rendering Drawing Clippaths with canvas transformation
-	    #2.4.4.8
-	    - fix: Drawing Clippaths
-	    #2.4.4.6
-	    - fix: TextTool, when text edit, textspan renders not with bound from last textspan
-	    - fix: TextTool, removing lines until one remains, updates 
-	    #2.4.4.5
+		#2.4.4.10
+		- fix: Svg Plan throws no instance of an object error on drawing pathsegment
+		#2.4.4.9
+		- fix: rendering Drawing Clippaths with canvas transformation
+		#2.4.4.8
+		- fix: Drawing Clippaths
+		#2.4.4.6
+		- fix: TextTool, when text edit, textspan renders not with bound from last textspan
+		- fix: TextTool, removing lines until one remains, updates
+		#2.4.4.5
 		- fix: arrow tips too large
-	    #2.4.4.4.4
+		#2.4.4.4.4
 		- fix: Arrow tips of lines are not filled (transparent)
-	    #2.4.4.3
-	    - fix: can not parse 4-digit color values 
-	    
-	    #2.4.4.2
+		#2.4.4.3
+		- fix: can not parse 4-digit color values
+
+		#2.4.4.2
 		- fix: SvgDocument.DeepCopy&lt;T&gt; also copies stylesheets
 	    
 	    #2.4.4.1


### PR DESCRIPTION
The issue is that the line segments after close segment Z have a start path of null but it should start from the first move M.

If the Start path is null, we set it to the first path from graphicspath. 

The first path is always a move M no other path segment can stay fist.
![grafik](https://github.com/gentledepp/SVG/assets/44953551/0659641b-9f78-45be-98fe-7ee63adf3dcb)



