### PR TITLE
SvgDocument creates ambient SvgRenderer that can cache Fonts, Brushes…

### DIFF
--- a/Svg/Svg.csproj
+++ b/Svg/Svg.csproj
@@ -3,11 +3,13 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;MonoAndroid81;Xamarin.iOS10;uap10.0.18362;net462</TargetFrameworks>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-    <Version>2.4.4.11</Version>
+    <Version>2.4.4.12</Version>
     <Authors>gentledpp,bruzkovsky</Authors>
     <Company>Opti-Q GmbH</Company>
     <PackageReleaseNotes>
-		#2.4.4.11
+		#2.4.4.12
+		- SvgDocument creates ambient SvgRenderer that can cache Fonts, Brushes etc. for one render/bounds-calculation run
+	    #2.4.4.11
 		- fix: SvgUse now correctly calculates its bounds by forwarding the bounds of its referenced element
 		#2.4.4.10
 		- fix: Svg Plan throws no instance of an object error on drawing pathsegment

--- a/Svg/SvgDocument.cs
+++ b/Svg/SvgDocument.cs
@@ -9,6 +9,7 @@ using Svg.Css;
 using System.Globalization;
 using Svg.Interfaces;
 using Svg.Interfaces.Xml;
+using Svg.Platform;
 using Svg.Transforms;
 using RectangleF = Svg.Interfaces.RectangleF;
 
@@ -500,23 +501,25 @@ namespace Svg
         {
             try
             {
-                using (var renderer = SvgRenderer.FromImage(bitmap))
-                {
-                    if (backgroundColor != null)
+                // we need a renderer for caching
+                using var rendererHandle = CreateRendererFromImage(bitmap);
+                
+                var renderer = rendererHandle.Renderer;
+
+                if (backgroundColor != null)
                         renderer.FillBackground(backgroundColor);
 
-                    renderer.SetBoundable(new GenericBoundable(0, 0, bitmap.Width, bitmap.Height));
+                renderer.SetBoundable(new GenericBoundable(0, 0, bitmap.Width, bitmap.Height));
 
-                    //EO, 2014-12-05: Requested to ensure proper zooming (draw the svg in the bitmap size, ==> proper scaling)
-                    //EO, 2015-01-09, Added GetDimensions to use its returned size instead of this.Width and this.Height (request of Icarrere).
-                    var size = this.GetDimensions();
-                    renderer.ScaleTransform(bitmap.Width / size.Width, bitmap.Height / size.Height);
+                //EO, 2014-12-05: Requested to ensure proper zooming (draw the svg in the bitmap size, ==> proper scaling)
+                //EO, 2015-01-09, Added GetDimensions to use its returned size instead of this.Width and this.Height (request of Icarrere).
+                var size = this.GetDimensions();
+                renderer.ScaleTransform(bitmap.Width / size.Width, bitmap.Height / size.Height);
 
-                    //EO, 2014-12-05: Requested to ensure proper zooming out (reduce size). Otherwise it clip the image.
-                    this.Overflow = SvgOverflow.Auto;
+                //EO, 2014-12-05: Requested to ensure proper zooming out (reduce size). Otherwise it clip the image.
+                this.Overflow = SvgOverflow.Auto;
 
-                    this.Render(renderer);
-                }
+                this.Render(renderer);
             }
             catch
             {
@@ -724,9 +727,12 @@ namespace Svg
             ViewBox = new SvgViewBox(bounds.X, bounds.Y, bounds.Width, bounds.Height);
             Draw(bitmap, backgroundColor);
         }
-
+        
         public RectangleF CalculateDocumentBounds()
         {
+            // we need a renderer for caching
+            using var renderer = CreateRendererFromNull();
+
             RectangleF documentSize = null;
 
             foreach (var element in Children.OfType<SvgVisualElement>())
@@ -837,5 +843,48 @@ namespace Svg
                 c.Dispose();
             base.DisposeOverride();
         }
+
+        #region SvgRenderer caching/handling
+        
+        internal ISvgRenderer CurrentRenderer { get; private set; }
+
+        internal class SvgRendererHandle : IDisposable
+        {
+            private readonly SvgDocument _owner;
+            private readonly bool _isCreatorHandle;
+            public ISvgRenderer Renderer { get; }
+
+            public SvgRendererHandle(ISvgRenderer renderer, SvgDocument owner, bool isCreatorHandle)
+            {
+                _owner = owner;
+                _isCreatorHandle = isCreatorHandle;
+                Renderer = renderer;
+            }
+
+            public void Dispose()
+            {
+                if (!_isCreatorHandle)
+                    return;
+
+                _owner.CurrentRenderer = null;
+                Renderer?.Dispose();
+            }
+        }
+
+        internal SvgRendererHandle CreateRendererFromImage(Bitmap bitmap)
+        {
+            if (CurrentRenderer != null)
+                return new SvgRendererHandle(CurrentRenderer, this, false);
+
+            CurrentRenderer = SvgRenderer.FromImage(bitmap);
+            return new SvgRendererHandle(CurrentRenderer, this, true);
+        }
+        
+        internal SvgRendererHandle CreateRendererFromNull()
+        {
+            return CreateRendererFromImage(Bitmap.Create(1, 1));
+        }
+
+        #endregion
     }
 }

--- a/Svg/Text/SvgTextBase.cs
+++ b/Svg/Text/SvgTextBase.cs
@@ -271,7 +271,13 @@ namespace Svg
             RectangleF b;
             if (_alternativeTextRenderer != null)
             {
-                b = _alternativeTextRenderer.GetBounds(this, SvgRenderer.FromNull());
+                if (this.OwnerDocument is { } doc)
+                {
+                    using var handle = doc.CreateRendererFromNull();
+                    b = _alternativeTextRenderer.GetBounds(this, handle.Renderer);
+                }
+                else
+                    b = _alternativeTextRenderer.GetBounds(this, SvgRenderer.FromNull());
             }
             else
             {


### PR DESCRIPTION
… etc. for one render/bounds-calculation run

this fixed one performance issue, that "CalculateDocumentBounds" for some ISS plan loaded a custom font over and over again.

Using caching, this font can just be re-used