### PR TITLE
- SvgDocument - fixed calculating document bounds (clippath is taken …

### DIFF
--- a/Svg/Svg.csproj
+++ b/Svg/Svg.csproj
@@ -1,115 +1,116 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net462;net9.0-windows10.0.19041.0</TargetFrameworks>
-    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+    <PropertyGroup>
+        <TargetFrameworks>netstandard2.0;net48;net9.0</TargetFrameworks>
+        <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+        <Version>3.0.7-alpha-avalonia</Version>
+        <Authors>gentledpp,zepr</Authors>
+        <Company>Opti-Q GmbH</Company>
+        <PackageReleaseNotes>
+            #3.0.0-alpha-avalonia
+            - migrate to avalonia
+            #2.4.4.13
+            - SvgDocument - fixed calculating document bounds (clippath is taken into account)
+            - SvgDocument - Improved performance as using GetBounds and not GetTransformedElementPoints which returned millions of points as arrays
+            #2.4.4.12
+            - SvgDocument creates ambient SvgRenderer that can cache Fonts, Brushes etc. for one render/bounds-calculation run
+            #2.4.4.11
+            - fix: SvgUse now correctly calculates its bounds by forwarding the bounds of its referenced element
+            #2.4.4.10
+            - fix: Svg Plan throws no instance of an object error on drawing pathsegment
+            #2.4.4.9
+            - fix: rendering Drawing Clippaths with canvas transformation
+            #2.4.4.8
+            - fix: Drawing Clippaths
+            #2.4.4.7
+            - fix: RectangleTool's icon
+            #2.4.4.6
+            - fix: TextTool, when text edit, textspan renders not with bound from last textspan
+            - fix: TextTool, removing lines until one remains, updates
+            #2.4.4.5
+            - fix: arrow tips too large
+            #2.4.4.4.4
+            - fix: Arrow tips of lines are not filled (transparent)
+            #2.4.4.3
+            - fix: can not parse 4-digit color values
 
-    <Version>3.0.7-alpha-avalonia</Version>
-    <Authors>gentledepp,zepr</Authors>
-    <Company>Opti-Q GmbH</Company>
-    <PackageReleaseNotes>
-		#3.0.0-alpha-avalonia
-			migrate to avalonia
-		#2.4.4.12
-		- SvgDocument creates ambient SvgRenderer that can cache Fonts, Brushes etc. for one render/bounds-calculation run
-	  #2.4.4.11
-		- fix: SvgUse now correctly calculates its bounds by forwarding the bounds of its referenced element
-		#2.4.4.10
-		- fix: Svg Plan throws no instance of an object error on drawing pathsegment
-		#2.4.4.9
-		- fix: rendering Drawing Clippaths with canvas transformation
-		#2.4.4.8
-		- fix: Drawing Clippaths
-    #2.4.4.7
-    - fix: RectangleTool's icon
-	    #2.4.4.6
-	    - fix: TextTool, when text edit, textspan renders not with bound from last textspan
-	    - fix: TextTool, removing lines until one remains, updates 
-	    #2.4.4.5
-		- fix: arrow tips too large
-		#2.4.4.4.4
-		- fix: Arrow tips of lines are not filled (transparent)
-		#2.4.4.3
-		- fix: can not parse 4-digit color values
+            #2.4.4.2
+            - fix: SvgDocument.DeepCopy&lt;T&gt; also copies stylesheets
 
-		#2.4.4.2
-		- fix: SvgDocument.DeepCopy&lt;T&gt; also copies stylesheets
-	    
-	    #2.4.4.1
-		- major performance improvements by caching pens and paints
-		- support for custom OTF fonts
-		- text rendering improvements
-		
-		#2.4.3.16
-		- Render tspan in textrenderer
+            #2.4.4.1
+            - major performance improvements by caching pens and paints
+            - support for custom OTF fonts
+            - text rendering improvements
 
-		#2.4.3.15
-		- Render tspan in textrenderer
+            #2.4.3.16
+            - Render tspan in textrenderer
+
+            #2.4.3.15
+            - Render tspan in textrenderer
 
 
-		#2.4.3.14
-		- DrawAllContents with Original SvgDocument size
+            #2.4.3.14
+            - DrawAllContents with Original SvgDocument size
 
-		#2.4.3.13
-		- Texterendering renders with default size when no size available
+            #2.4.3.13
+            - Texterendering renders with default size when no size available
 
-		#2.4.3.10 - 11
-		- add OnScreenSet event in SvgDrawingCanvas after Screen properties set in OnDraw method
+            #2.4.3.10 - 11
+            - add OnScreenSet event in SvgDrawingCanvas after Screen properties set in OnDraw method
 
-		# 2.4.3.9
-		- fix WebRequestSvc to handle path correctly (for real this time)
+            # 2.4.3.9
+            - fix WebRequestSvc to handle path correctly (for real this time)
 
-		# 2.4.3.7
-		- bumped version for 2.4.3.6
+            # 2.4.3.7
+            - bumped version for 2.4.3.6
 
-		# 2.4.3.6
-		- fix WebRequestSvc to handle path correctly
+            # 2.4.3.6
+            - fix WebRequestSvc to handle path correctly
 
-		# 2.4.3.5
-		- changed "Href" property of SvgImage from Uri to string, as System.Uri throws in case a url is too long
+            # 2.4.3.5
+            - changed "Href" property of SvgImage from Uri to string, as System.Uri throws in case a url is too long
 
-		# 2.4.3.4
-		- antialiasing on by default
+            # 2.4.3.4
+            - antialiasing on by default
 
-		# 2.4.3.3
-		- netstandard multiplatform
-	</PackageReleaseNotes>
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
+            # 2.4.3.3
+            - netstandard multiplatform
+        </PackageReleaseNotes>
+        <LangVersion>latest</LangVersion>
+    </PropertyGroup>
 
-  <PropertyGroup Condition="$(Configuration) == 'Release'">
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <IncludeSource>True</IncludeSource>
-    <IncludeSymbols>True</IncludeSymbols>
-  </PropertyGroup>
+    <PropertyGroup Condition="$(Configuration) == 'Release'">
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <IncludeSource>True</IncludeSource>
+        <IncludeSymbols>True</IncludeSymbols>
+    </PropertyGroup>
 
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('net4')) ">
-    <DefineConstants>Net4</DefineConstants>
-  </PropertyGroup>
+    <PropertyGroup Condition="$(TargetFramework.StartsWith('net4')) ">
+        <DefineConstants>Net4</DefineConstants>
+    </PropertyGroup>
 
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('uap')) ">
-    <Compile Include="Platforms\UniversalWindows\**\*.cs" />
-  </ItemGroup>
 
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
-    <Compile Include="Platforms\Android\**\*.cs" />
-    <PackageReference Include="System.Xml.ReaderWriter" Version="4.3.0" />
 
-  </ItemGroup>
+    <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
+        <Compile Include="Platforms\Android\**\*.cs" />
+        <PackageReference Include="System.Xml.ReaderWriter" Version="4.3.0" />
 
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('Xamarin.iOS')) ">
-    <Compile Include="Platforms\iOS\**\*.cs" />
-  </ItemGroup>
+    </ItemGroup>
 
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
-    <Compile Include="Platforms\Win\**\*.cs" />
-  </ItemGroup>
+    <ItemGroup Condition=" $(TargetFramework.StartsWith('Xamarin.iOS')) ">
+        <Compile Include="Platforms\iOS\**\*.cs" />
+    </ItemGroup>
 
-  <ItemGroup>
-	  <PackageReference Include="Avalonia.Skia" Version="11.2.1" />
-    <PackageReference Include="System.IO.Compression" Version="4.3.0" />
-    <PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
-  </ItemGroup>
+    <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
+        <Compile Include="Platforms\Win\**\*.cs" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="SkiaSharp" Version="2.88.8" />
+        <PackageReference Include="System.IO.Compression" Version="4.3.0" />
+        <PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
+    </ItemGroup>
+
 
 
 </Project>

--- a/Svg/SvgDocument.cs
+++ b/Svg/SvgDocument.cs
@@ -738,7 +738,7 @@ namespace Svg
 
             foreach (var element in Children.OfType<SvgVisualElement>())
             {
-                var bounds = element.GetBoundingBox();
+                var bounds = element.GetBounds();
 
                 if (documentSize == null)
                     documentSize = bounds;


### PR DESCRIPTION
…into account)

- SvgDocument - Improved performance as using GetBounds and not GetTransformedElementPoints which returned millions of points as arrays