### PR TITLE
#13037 - reduced GC pressure in FreeDrawingTool and SvgDrawingCanvase…

### DIFF
--- a/Svg.Editor.Avalonia.Forms/Svg.Editor.Avalon.Forms.csproj
+++ b/Svg.Editor.Avalonia.Forms/Svg.Editor.Avalon.Forms.csproj
@@ -3,8 +3,12 @@
 		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<LangVersion>latest</LangVersion>
-		<Version>3.1.1</Version>
+		<Version>3.1.2-optiq02</Version>
 		<PackageReleaseNotes>
+			#3.1.2-optiq02
+			performance improvements
+			#3.1.2-optiq01
+			bumped version
 			#3.1.1
 			- reduced memory/GC pressure
 			#3.1.0

--- a/Svg.Editor.Avalonia.Views/Svg.Editor.Avalon.Views.csproj
+++ b/Svg.Editor.Avalonia.Views/Svg.Editor.Avalon.Views.csproj
@@ -3,8 +3,12 @@
 		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<LangVersion>latest</LangVersion>
-		<Version>3.1.1</Version>
+		<Version>3.1.2-optiq02</Version>
 		<PackageReleaseNotes>
+			#3.1.2-optiq02
+			performance improvements
+			#3.1.2-optiq01
+			bumped version
 			#3.1.1
 			- reduced memory/GC pressure
 			#3.1.0

--- a/Svg.Editor.Core/Svg.Editor.Core.csproj
+++ b/Svg.Editor.Core/Svg.Editor.Core.csproj
@@ -4,9 +4,13 @@
     <AssemblyName>Svg.Editor</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetFramework>netstandard2.0</TargetFramework>
-	  <Version>3.1.1</Version>
+	  <Version>3.1.2-optiq02</Version>
 	  <LangVersion>latest</LangVersion>
 	  <PackageReleaseNotes>
+		  #3.1.2-optiq02
+		  performance improvements
+		  #3.1.2-optiq01
+		  bumped version
 		  #3.1.1
 		  - reduced memory/GC pressure
 		  #3.1.0

--- a/Svg.Tests.Win/Svg.Tests.Win.csproj
+++ b/Svg.Tests.Win/Svg.Tests.Win.csproj
@@ -26,11 +26,12 @@
 
     <ItemGroup>
         <PackageReference Include="JetBrains.DotMemoryUnit" Version="3.2.20220510" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
         <PackageReference Include="Moq" Version="4.18.4" />
         <PackageReference Include="NUnit" Version="3.12.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
         <PackageReference Include="Shouldly" Version="4.3.0" />
-        <PackageReference Include="SkiaSharp" Version="2.88.8" />
+        <PackageReference Include="SkiaSharp" Version="3.119.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Svg.Tests.Win/TestHelper.cs
+++ b/Svg.Tests.Win/TestHelper.cs
@@ -22,18 +22,15 @@ namespace Svg.Tests.Win
             using var src = File.OpenRead(svgPath);
 
             using SvgDocument doc = SvgDocument.Open<SvgDocument>(src);
-            using var surface = SKSurface.Create(width, height, SKImageInfo.PlatformColorType, SKAlphaType.Premul);
+            using var surface = SKSurface.Create(new SKImageInfo(width, height));
 
             using var renderer = SvgRenderer.FromGraphics(new SkiaGraphics(surface));
             if(backgroundColor != null)
                 renderer.FillBackground(backgroundColor);
-            
-            doc.Draw(renderer);
-            var img = surface.Snapshot();
 
-            using var s = new SKManagedStream(img.Encode().AsStream());
-            SKBitmap b = new SKBitmap();
-            return SKBitmap.Decode(s);
+            doc.Draw(renderer);
+            using var img = surface.Snapshot();
+            return SKBitmap.FromImage(img);
         }
 
         public static ImageCompareResult ImageCompare(SKBitmap actual, SKBitmap expected)
@@ -86,18 +83,8 @@ namespace Svg.Tests.Win
             if (!Path.IsPathRooted(pngPath))
                 pngPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "Assets", pngPath);
 
-            using var ms = new MemoryStream();
-            using (var stream = File.OpenRead(pngPath))
-            {
-                stream.CopyTo(ms);
-                ms.Seek(0, SeekOrigin.Begin);
-            }
-
-            using (var pngStream = new SKManagedStream(ms))
-            {
-                var pngBitmap = SKBitmap.Decode(pngStream);
-                return pngBitmap;
-            }
+            using var stream = File.OpenRead(pngPath);
+            return SKBitmap.Decode(stream);
         }
     }
 
@@ -131,10 +118,16 @@ namespace Svg.Tests.Win
         {
             if (res.Similarity < similarity)
             {
-                SKPixmap.Encode(new SKFileWStream($"{testMethodName}{postFix}_difference.png"),
-                    res.Heatmap, SKEncodedImageFormat.Png, 100);
-                SKPixmap.Encode(new SKFileWStream($"{testMethodName}{postFix}_actual.png"),
-                    res.ActualResult, SKEncodedImageFormat.Png, 100);
+                using (var heatmapImage = SKImage.FromBitmap(res.Heatmap))
+                using (var heatmapData = heatmapImage.Encode(SKEncodedImageFormat.Png, 100))
+                {
+                    File.WriteAllBytes($"{testMethodName}{postFix}_difference.png", heatmapData.ToArray());
+                }
+                using (var actualImage = SKImage.FromBitmap(res.ActualResult))
+                using (var actualData = actualImage.Encode(SKEncodedImageFormat.Png, 100))
+                {
+                    File.WriteAllBytes($"{testMethodName}{postFix}_actual.png", actualData.ToArray());
+                }
                 Console.WriteLine($"Saved heatmap in {Path.Combine(Environment.CurrentDirectory, $"{testMethodName}{postFix}_difference.png")}");
             }
             Assert.GreaterOrEqual(res.Similarity, similarity);

--- a/Svg/Clipping and Masking/SvgClipPath.cs
+++ b/Svg/Clipping and Masking/SvgClipPath.cs
@@ -60,7 +60,6 @@ namespace Svg
             var result = cachedClipPath.Clone();
             if (ClipPathUnits == SvgCoordinateUnits.ObjectBoundingBox)
             {
-                result = (GraphicsPath)cachedClipPath.Clone();
                 using (var transform = SvgEngine.Factory.CreateMatrix())
                 {
                     var bounds = owner.Bounds;

--- a/Svg/Platform/SkiaGraphics.cs
+++ b/Svg/Platform/SkiaGraphics.cs
@@ -139,12 +139,20 @@ namespace Svg.Platform
 
         public void SetClip(GraphicsPath path, CombineMode combineMode)
         {
-            _clipPath = ((SkiaGraphicsPath)path).Path;
-
             if (path != null)
             {
+                _clipPath = ((SkiaGraphicsPath)path).Path;
+
+                // Use ClipPath instead of ClipRegion(new SKRegion(...)) to avoid
+                // expensive path-to-region rasterization (SKRegion.SetPath/SetRects).
+                // Since ClipPath applies the current canvas matrix but the clip path
+                // needs to be transformed by TotalMatrix to device coordinates,
+                // we temporarily set identity matrix and clip with the pre-transformed path.
                 _clipPath.Transform(_canvas.TotalMatrix);
-                _canvas.ClipRegion(new SKRegion(_clipPath), SKClipOperation.Intersect);
+                var savedMatrix = _canvas.TotalMatrix;
+                _canvas.SetMatrix(SKMatrix.Identity);
+                _canvas.ClipPath(_clipPath, SKClipOperation.Intersect, false);
+                _canvas.SetMatrix(savedMatrix);
             }
         }
 

--- a/Svg/Svg.csproj
+++ b/Svg/Svg.csproj
@@ -3,13 +3,17 @@
     <PropertyGroup>
         <TargetFrameworks>netstandard2.0;net48;net9.0</TargetFrameworks>
         <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-        <Version>3.1.1</Version>
+        <Version>3.1.2-optiq02</Version>
         <Authors>gentledpp,zepr</Authors>
         <Company>Opti-Q GmbH</Company>
         <PackageReleaseNotes>
-			#3.1.1
+	        #3.1.2-optiq02
+			performance improvements
+			#3.1.2-optiq01
+			bumped version
+			~#3.1.1~ version exists on public nuget
 			- reduced memory/GC pressure
-            #3.1.0
+			#3.1.0
 			- bumped version along with editor
 			#3.0.8
 			- fixed clippath tests

--- a/Svg/Text/SvgTextBase.cs
+++ b/Svg/Text/SvgTextBase.cs
@@ -357,15 +357,41 @@ namespace Svg
         public override GraphicsPath Path(ISvgRenderer renderer)
         {
             //if there is a TSpan inside of this text element then path should not be null (even if this text is empty!)
-            var nodes = GetContentNodes().Where(x => x is SvgContentNode &&
-                                                     string.IsNullOrEmpty(x.Content.Trim(new[] { '\r', '\n', '\t' })));
-
-            if (_path == null || IsPathDirty || nodes.Count() == 1)
+            if (_path == null || IsPathDirty || HasSingleEmptyContentNode())
             {
                 renderer = (renderer ?? SvgRenderer.FromNull());
                 SetPath(new TextDrawingState(renderer, this));
             }
             return _path;
+        }
+
+        /// <summary>
+        /// Checks if this text element has exactly one empty content node.
+        /// Avoids LINQ allocations by using a simple loop with early exit.
+        /// </summary>
+        private bool HasSingleEmptyContentNode()
+        {
+            int count = 0;
+            foreach (var node in GetContentNodes())
+            {
+                if (node is SvgContentNode && IsEmptyOrWhitespaceOnly(node.Content))
+                {
+                    count++;
+                    if (count > 1) return false;
+                }
+            }
+            return count == 1;
+        }
+
+        private static bool IsEmptyOrWhitespaceOnly(string s)
+        {
+            if (string.IsNullOrEmpty(s)) return true;
+            for (int i = 0; i < s.Length; i++)
+            {
+                var c = s[i];
+                if (c != '\r' && c != '\n' && c != '\t') return false;
+            }
+            return true;
         }
 
         private void SetPath(TextDrawingState state)


### PR DESCRIPTION
… (Linq usage)

- reduced allocation of SKPoints
- reduced GC pressure in GridTool
- fixed NRE in SvgHitTestingExtensions.cs
- improved performance (SvgTextBase, SvgClipPath, SkiaGraphics)
- moved to SkiaSharp 3.119.1