### PR TITLE
Fix editor always zooming out on images and incorrect zoom restore

### DIFF
--- a/Svg.Editor.Avalonia.Forms/Svg.Editor.Avalon.Forms.csproj
+++ b/Svg.Editor.Avalonia.Forms/Svg.Editor.Avalon.Forms.csproj
@@ -3,8 +3,11 @@
 		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<LangVersion>latest</LangVersion>
-		<Version>3.1.2-optiq03</Version>
+		<Version>3.1.2-optiq05</Version>
 		<PackageReleaseNotes>
+			#3.1.2-optiq05
+			Zoom factor derivation from viewbox math fix
+			Images not setting constraints fix
 			#3.1.2-optiq03
 			DPI calculation fixes
 			FreeDrwaingTool path Bounds fix

--- a/Svg.Editor.Avalonia.Views/Svg.Editor.Avalon.Views.csproj
+++ b/Svg.Editor.Avalonia.Views/Svg.Editor.Avalon.Views.csproj
@@ -3,8 +3,11 @@
 		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<LangVersion>latest</LangVersion>
-		<Version>3.1.2-optiq03</Version>
+		<Version>3.1.2-optiq05</Version>
 		<PackageReleaseNotes>
+			#3.1.2-optiq05
+			Zoom factor derivation from viewbox math fix
+			Images not setting constraints fix
 			#3.1.2-optiq03
 			DPI calculation fixes
 			FreeDrwaingTool path Bounds fix

--- a/Svg.Editor.Core.Tests/PlaceAsBackgroundToolTests.cs
+++ b/Svg.Editor.Core.Tests/PlaceAsBackgroundToolTests.cs
@@ -5,6 +5,7 @@ using Svg.Editor.Tools;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Svg.Interfaces;
 
 namespace Svg.Editor.Core.Tests
 {
@@ -31,7 +32,8 @@ namespace Svg.Editor.Core.Tests
             // Arrange
             await Canvas.EnsureInitialized();
 
-            Assert.That(Canvas.Constraints != null, "Using a background image should constrain the editor to that image");
+            var expectedConstraints = RectangleF.Create(0, 0, 2026.499f, 1184);
+            Assert.That(Canvas.Constraints.Equals(expectedConstraints), "Using a background image should constrain the editor to that image");
         }
     }
 }

--- a/Svg.Editor.Core.Tests/PlaceAsBackgroundToolTests.cs
+++ b/Svg.Editor.Core.Tests/PlaceAsBackgroundToolTests.cs
@@ -1,0 +1,37 @@
+﻿using NUnit.Framework;
+using Svg.Editor.Core.Test;
+using Svg.Editor.Interfaces;
+using Svg.Editor.Tools;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Svg.Editor.Core.Tests
+{
+    [TestFixture]
+    public class PlaceAsBackgroundToolTests : SvgDrawingCanvasTestBase
+    {
+        [SetUp]
+        protected override void SetupOverride()
+        {
+            var imagePath = System.IO.Path.Combine(TestContext.CurrentContext.TestDirectory, "Assets", "iso_sketch_large.svg");
+            var placeAsBackgroundToolProperties = new Dictionary<string, object>
+            {
+                { PlaceAsBackgroundTool.ImagePathKey, imagePath },
+                { PlaceAsBackgroundTool.ChooseBackgroundEnabledKey, false }
+            };
+
+            Canvas.LoadTools(
+                () => new PlaceAsBackgroundTool(placeAsBackgroundToolProperties, SvgEngine.Resolve<IUndoRedoService>()));
+        }
+
+        [Test]
+        public async Task WhenInitialized_SetsConstraints()
+        {
+            // Arrange
+            await Canvas.EnsureInitialized();
+
+            Assert.That(Canvas.Constraints != null, "Using a background image should constrain the editor to that image");
+        }
+    }
+}

--- a/Svg.Editor.Core.Tests/Svg.Editor.Core.Tests.csproj
+++ b/Svg.Editor.Core.Tests/Svg.Editor.Core.Tests.csproj
@@ -86,6 +86,7 @@
     <Compile Include="TransformationTests.cs" />
     <Compile Include="UndoRedoToolTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="PlaceAsBackgroundToolTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia.Skia">

--- a/Svg.Editor.Core.Tests/SvgDrawingCanvasTests.cs
+++ b/Svg.Editor.Core.Tests/SvgDrawingCanvasTests.cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using SkiaSharp;
 using Svg.Editor.Interfaces;
+using Svg.Editor.Services;
 using Svg.Editor.Tools;
 using Svg.Interfaces;
 
@@ -203,6 +205,37 @@ namespace Svg.Editor.Core.Test
             var json = Canvas.GetToolPropertiesJson();
 
             Assert.False(string.IsNullOrWhiteSpace(json));
+        }
+
+        [Test]
+        [TestCase(0, 0, 400, 600, 800, 600, 1.0f, 0, 0)]
+        [TestCase(0, 0, 800, 300, 800, 600, 1.0f, 0, 0)]
+        [TestCase(0, 0, 1600, 1200, 800, 600, 0.5f, 0, 0)]
+        [TestCase(0, 0, 400, 300, 800, 600, 2.0f, 0, 0)]
+        [TestCase(100, 50, 400, 300, 800, 600, 2.0f, -200, -100)]
+        [TestCase(-50, -50, 400, 600, 800, 600, 1.0f, 50, 50)]
+        public async Task CalculatesZoomFactorAndTranslateCorrectly(
+            float vbX, float vbY, float vbWidth, float vbHeight,
+            int screenWidth, int screenHeight,
+            float expectedZoomFactor, float expectedTranslateX, float expectedTranslateY)
+        {
+            // Arrange
+            await Canvas.EnsureInitialized();
+
+            var d = new SvgDocument();
+            d.ViewBox = new SvgViewBox(vbX, vbY, vbWidth, vbHeight);
+            Canvas.ScreenWidth = screenWidth;
+            Canvas.ScreenHeight = screenHeight;
+            Canvas.Document = d;
+
+            using var surface1 = SKSurface.Create(screenWidth, screenHeight, SKImageInfo.PlatformColorType, SKAlphaType.Premul);
+            var renderer1 = new SKCanvasRenderer(surface1, screenWidth, screenHeight);
+            await Canvas.OnDraw(renderer1);
+
+            // Assert
+            Assert.AreEqual(expectedZoomFactor, Canvas.ZoomFactor);
+            Assert.AreEqual(expectedTranslateX, Canvas.Translate.X);
+            Assert.AreEqual(expectedTranslateY, Canvas.Translate.Y);
         }
 
         private class MockTextInputService : ITextInputService

--- a/Svg.Editor.Core/Svg.Editor.Core.csproj
+++ b/Svg.Editor.Core/Svg.Editor.Core.csproj
@@ -4,9 +4,12 @@
     <AssemblyName>Svg.Editor</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetFramework>netstandard2.0</TargetFramework>
-	  <Version>3.1.2-optiq03</Version>
+	  <Version>3.1.2-optiq05</Version>
 	  <LangVersion>latest</LangVersion>
 	  <PackageReleaseNotes>
+		  #3.1.2-optiq05
+		  Zoom factor derivation from viewbox math fix
+		  Images not setting constraints fix
 		  #3.1.2-optiq03
 		  DPI calculation fixes
 		  FreeDrwaingTool path Bounds fix

--- a/Svg.Editor.Core/SvgDrawingCanvas.cs
+++ b/Svg.Editor.Core/SvgDrawingCanvas.cs
@@ -427,15 +427,12 @@ namespace Svg.Editor
             }
         }
 
-        private bool Loading { get; set; } = true;
         private void ApplyConstraintsFitUniform()
         {
             if (Constraints == null || Constraints == RectangleF.Empty) return;
 
             // if zoom is totally out of bounds, reset
-            // or: when loading, zoom out
-            if ((ScreenWidth / ZoomFactor > Constraints.Width && ScreenHeight / ZoomFactor > Constraints.Height)
-                || Loading)
+            if (ScreenWidth / ZoomFactor > Constraints.Width && ScreenHeight / ZoomFactor > Constraints.Height)
             {
                 ZoomFactor = Math.Min(ScreenWidth / Constraints.Width,
                     ScreenHeight / Constraints.Height);
@@ -444,7 +441,6 @@ namespace Svg.Editor
                     (ScreenHeight - Constraints.Height * ZoomFactor) / 2);
                 // this should replace "ZoomFocus = PointF.Empty;" but doesn't work when ZoomFactor < 1
                 //+ (ZoomFocus - ScreenToCanvas(0, 0)) * (ZoomFactor - 1);
-                Loading = false;
                 return;
             }
             var constraintTopLeft = PointF.Create(Constraints.Left, Constraints.Top) * ZoomFactor;
@@ -1026,18 +1022,27 @@ namespace Svg.Editor
             }
             else if (Document != null)
             {
+                var viewBox = Document.ViewBox;
 
-                float scaleX;
-                float scaleY;
-                float minX;
-                float minY;
-                Document.ViewBox.CalculateTransform(Document.AspectRatio, ScreenWidth, ScreenHeight,
-                    out scaleX, out scaleY, out minX, out minY);
+                if (viewBox.Width <= 0 || viewBox.Height <= 0 || ScreenWidth <= 0 || ScreenHeight <= 0)
+                {
+                    ZoomFactor = 1f;
+                    ZoomFocus = PointF.Empty;
+                    Translate = PointF.Create(0f, 0f);
+                }
+                else
+                {
+                    // restore camera from saved viewbox dimensions
+                    // e.g. ScreenWidth = 1000, viewBox.Width = 2000, ZoomFactor should be 0.5
+                    var zoomX = (float)ScreenWidth / viewBox.Width;
+                    var zoomY = (float)ScreenHeight / viewBox.Height;
+                    ZoomFactor = Math.Min(zoomX, zoomY);
 
-                ZoomFactor = Math.Min(1 / scaleX, 1 / scaleY);
-                ZoomFocus = PointF.Empty;
-                Translate = PointF.Create(-Document.ViewBox.MinX * ZoomFactor, -Document.ViewBox.MinY * ZoomFactor);
-
+                    ZoomFocus = PointF.Empty;
+                    Translate = PointF.Create(
+                        -viewBox.MinX * ZoomFactor,
+                        -viewBox.MinY * ZoomFactor);
+                }
             }
 
             // we need to reset the viewBox for correct rendering afterwards

--- a/Svg.Editor.Core/Tools/PlaceAsBackgroundTool.cs
+++ b/Svg.Editor.Core/Tools/PlaceAsBackgroundTool.cs
@@ -150,7 +150,7 @@ namespace Svg.Editor.Tools
                 // add constraints to the canvas
                 var size = image.GetImageSize();
 
-                //Canvas.Constraints = RectangleF.Create(0, 0, size.Width, size.Height);
+                Canvas.Constraints = RectangleF.Create(0, 0, size.Width, size.Height);
                 Canvas.FireInvalidateCanvas();
                 Canvas.FireToolCommandsChanged();
             }

--- a/Svg/Svg.csproj
+++ b/Svg/Svg.csproj
@@ -3,10 +3,12 @@
     <PropertyGroup>
         <TargetFrameworks>netstandard2.0;net48;net9.0</TargetFrameworks>
         <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-        <Version>3.1.2-optiq04</Version>
+        <Version>3.1.2-optiq05</Version>
         <Authors>gentledpp,zepr</Authors>
         <Company>Opti-Q GmbH</Company>
         <PackageReleaseNotes>
+			#3.1.2-optiq05
+			bumped version along with editor
 	        #3.1.2-optiq04
 	        Added SvgElementCollection.DetachAll() — empties the collection without firing
 	        OnElementRemoved, without nulling item._parent, and without cascading through


### PR DESCRIPTION
- See bug #13135
- The editor now opens with the zoom factor and translate as when it was closed
- Background images now constrain the zoom factor to the image size
- The zoom factor and translate are now restored correctly (the math was wrong before)