### PR TITLE
#13228 - add better support for caching svgdocument instances for con…

### DIFF
--- a/Svg.Tests.Win/SvgElementCollectionTests.cs
+++ b/Svg.Tests.Win/SvgElementCollectionTests.cs
@@ -1,0 +1,108 @@
+using NUnit.Framework;
+using Shouldly;
+
+namespace Svg.Tests.Win
+{
+    [TestFixture]
+    public class SvgElementCollectionTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            SvgPlatform.Init();
+        }
+
+        [Test]
+        public void DetachAll_EmptiesCollection_WithoutNullingChildParents()
+        {
+            // Arrange — Remove() normally sets item._parent = null. DetachAll is the
+            // escape hatch for containers that share children with other owners and
+            // must leave the items' parent-pointers alone.
+            var doc = new SvgDocument();
+            var rect = new SvgRectangle { X = 0, Y = 0, Width = 10, Height = 10 };
+            var circle = new SvgCircle { Radius = 5 };
+            doc.Children.Add(rect);
+            doc.Children.Add(circle);
+            rect.Parent.ShouldBe(doc);
+            circle.Parent.ShouldBe(doc);
+
+            // Act
+            doc.Children.DetachAll();
+
+            // Assert
+            doc.Children.Count.ShouldBe(0);
+            rect.Parent.ShouldBe(doc, "DetachAll must not null _parent (Remove() does that)");
+            circle.Parent.ShouldBe(doc);
+        }
+
+        [Test]
+        public void DetachAll_DoesNotFireChildRemovedEvent()
+        {
+            // Arrange — Remove() raises ChildRemoved and invokes OnSubTreeChanged.
+            // DetachAll skips the notification so listeners don't observe a bogus
+            // "removal" when the container is just being torn down.
+            var doc = new SvgDocument();
+            doc.Children.Add(new SvgRectangle());
+            var removedEvents = 0;
+            doc.ChildRemoved += (_, _) => removedEvents++;
+
+            // Act
+            doc.Children.DetachAll();
+
+            // Assert
+            removedEvents.ShouldBe(0);
+        }
+
+        [Test]
+        public void DetachAll_DoesNotUnregisterChildrenFromIdManager()
+        {
+            // Arrange — Remove() cascades through OwnerDocument.IdManager to purge
+            // the removed subtree's IDs. DetachAll must NOT do that, so shared
+            // children remain addressable from their other owner's IdManager.
+            var doc = new SvgDocument();
+            var rect = new SvgRectangle { ID = "keep-me" };
+            doc.Children.Add(rect);
+            doc.IdManager.GetElementById("keep-me").ShouldBe(rect);
+
+            // Act
+            doc.Children.DetachAll();
+
+            // Assert
+            doc.IdManager.GetElementById("keep-me").ShouldBe(rect,
+                "DetachAll must leave the IdManager untouched");
+        }
+
+        [Test]
+        public void DetachAll_OnEmptyCollection_IsNoOp()
+        {
+            // Arrange
+            var doc = new SvgDocument();
+
+            // Act / Assert — must not throw
+            Should.NotThrow(() => doc.Children.DetachAll());
+            doc.Children.Count.ShouldBe(0);
+        }
+
+        [Test]
+        public void Clear_StillNullsParent_AndDetachAll_Does_Not()
+        {
+            // Arrange — pin down the contrast: Clear() goes through Remove() and
+            // nulls _parent; DetachAll() does not. Regression guard for either
+            // path accidentally taking on the other's behavior.
+            var docA = new SvgDocument();
+            var docB = new SvgDocument();
+            var rectCleared = new SvgRectangle();
+            var rectDetached = new SvgRectangle();
+            docA.Children.Add(rectCleared);
+            docB.Children.Add(rectDetached);
+
+            // Act
+            docA.Children.Clear();
+            docB.Children.DetachAll();
+
+            // Assert
+            rectCleared.Parent.ShouldBeNull("Clear() goes through Remove() which nulls _parent");
+            rectDetached.Parent.ShouldBe(docB, "DetachAll() must not null _parent");
+        }
+    }
+}

--- a/Svg/Svg.csproj
+++ b/Svg/Svg.csproj
@@ -3,10 +3,15 @@
     <PropertyGroup>
         <TargetFrameworks>netstandard2.0;net48;net9.0</TargetFrameworks>
         <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-        <Version>3.1.2-optiq03</Version>
+        <Version>3.1.2-optiq04</Version>
         <Authors>gentledpp,zepr</Authors>
         <Company>Opti-Q GmbH</Company>
         <PackageReleaseNotes>
+	        #3.1.2-optiq04
+	        Added SvgElementCollection.DetachAll() — empties the collection without firing
+	        OnElementRemoved, without nulling item._parent, and without cascading through
+	        the IdManager. Enables cache-style containers to tear down safely while
+	        sharing children with other owners.
 	        #3.1.2-optiq03
 	        DPI calculation fixes
 			FreeDrwaingTool path Bounds fix

--- a/Svg/SvgElementCollection.cs
+++ b/Svg/SvgElementCollection.cs
@@ -127,6 +127,18 @@ namespace Svg
             }
         }
 
+        /// <summary>
+        /// Empties the collection without firing <c>OnElementRemoved</c>, without nulling
+        /// each item's <c>_parent</c>, and without cascading through the owner document's
+        /// <see cref="SvgElementIdManager"/>. Intended for specialised containers (e.g.
+        /// caches) that share child references with other owners and must not disturb
+        /// those children when disposing the container.
+        /// </summary>
+        public void DetachAll()
+        {
+            this._elements.Clear();
+        }
+
         public bool Contains(SvgElement item)
         {
             return this._elements.Contains(item);


### PR DESCRIPTION
Added SvgElementCollection.DetachAll() — empties the collection without firing
OnElementRemoved, without nulling item._parent, and without cascading through
the IdManager. Enables cache-style containers to tear down safely while
sharing children with other owners.