### PR TITLE
Fix text clipping itself by inheriting the clip-path and tranforming it

### DIFF
--- a/Svg.Tests.Win/SvgClipPathTest.cs
+++ b/Svg.Tests.Win/SvgClipPathTest.cs
@@ -1,10 +1,7 @@
-﻿using System.Diagnostics;
-using System.Linq;
+﻿using System.Linq;
 using Shouldly;
 using NUnit.Framework;
 using SkiaSharp;
-using Svg.Interfaces;
-using Svg.Pathing;
 using Svg.Platform;
 
 namespace Svg.Tests.Win;
@@ -81,5 +78,111 @@ public class SvgClipPathTest
 
         Assert.AreEqual(clip.Bounds.Width, 200);
         Assert.AreEqual(clip.Bounds.Height, 50);
+    }
+
+    [Test]
+    public void WhenGroupClipPathContainsTextTransform_AndTextIsOutsideClip_TextShouldNotBeRendered()
+    {
+        // Arrange
+        const string svg =
+            """
+            <svg width="200" height="200" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+              <defs>
+                <clipPath id="c"><rect x="0" y="0" width="200" height="40" /></clipPath>
+              </defs>
+              <g clip-path="url(#c)"><text x="0" y="0" font-size="48" fill="black" transform="matrix(1 0 0 1 0 150)">text</text></g>
+            </svg>
+            """;
+
+        // Act
+        using var rendered = RenderSvgFromString(svg, 200, 200);
+
+        // Assert
+        CountNonTransparentPixels(rendered).ShouldBe(0);
+    }
+
+    [Test]
+    public void WhenGroupClipPathContainsTextTransform_AndTextIsInsideClip_TextShouldBeRendered()
+    {
+        // Arrange
+        const string svg =
+            """
+            <svg width="200" height="200" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+              <defs>
+                <clipPath id="c"><rect x="0" y="120" width="200" height="80" /></clipPath>
+              </defs>
+              <g clip-path="url(#c)">
+                <text x="0" y="0" font-size="48" fill="black" transform="matrix(1 0 0 1 0 150)">text</text>
+              </g>
+            </svg>
+            """;
+
+        // Act
+        using var rendered = RenderSvgFromString(svg, 200, 200);
+
+        // Assert
+        CountNonTransparentPixels(rendered).ShouldBeGreaterThan(0);
+    }
+
+    [Test]
+    public void WhenClipPathIsOnGroup_ChildTextTransformShouldNotMoveClipRegion()
+    {
+        // Arrange
+        const string svg =
+            """
+            <svg width="220" height="220" viewBox="0 0 220 220" xmlns="http://www.w3.org/2000/svg">
+              <defs>
+                <clipPath id="c"><rect x="0" y="0" width="220" height="60" /></clipPath>
+              </defs>
+              <g clip-path="url(#c)">
+                <text x="5" y="45" font-size="40" fill="black">top</text>
+                <text x="5" y="0" font-size="40" fill="black" transform="matrix(1 0 0 1 0 170)">bottom</text>
+              </g>
+            </svg>
+            """;
+
+        // Act
+        using var rendered = RenderSvgFromString(svg, 220, 220);
+
+        // Assert
+        CountNonTransparentPixelsInRegion(rendered, 0, 0, 220, 70).ShouldBeGreaterThan(0);
+        CountNonTransparentPixelsInRegion(rendered, 0, 150, 220, 70).ShouldBe(0);
+    }
+
+    private static SKBitmap RenderSvgFromString(string svg, int width, int height)
+    {
+        using SvgDocument doc = SvgDocument.FromSvg<SvgDocument>(svg);
+        using var surface = SKSurface.Create(new SKImageInfo(width, height));
+        using var renderer = SvgRenderer.FromGraphics(new SkiaGraphics(surface));
+        doc.Draw(renderer);
+        using var image = surface.Snapshot();
+        return SKBitmap.FromImage(image);
+    }
+
+    private static int CountNonTransparentPixels(SKBitmap bitmap)
+    {
+        return CountNonTransparentPixelsInRegion(bitmap, 0, 0, bitmap.Width, bitmap.Height);
+    }
+
+    private static int CountNonTransparentPixelsInRegion(SKBitmap bitmap, int x, int y, int width, int height)
+    {
+        var xStart = x < 0 ? 0 : x;
+        var yStart = y < 0 ? 0 : y;
+        var xEnd = x + width > bitmap.Width ? bitmap.Width : x + width;
+        var yEnd = y + height > bitmap.Height ? bitmap.Height : y + height;
+
+        var count = 0;
+        for (var yy = yStart; yy < yEnd; yy++)
+        {
+            for (var xx = xStart; xx < xEnd; xx++)
+            {
+                if (bitmap.GetPixel(xx, yy).Alpha > 0)
+                {
+                    count++;
+                }
+            }
+        }
+
+        return count;
     }
 }

--- a/Svg/Basic Shapes/SvgVisualElement.cs
+++ b/Svg/Basic Shapes/SvgVisualElement.cs
@@ -150,10 +150,10 @@ namespace Svg
             return true;
         }
 
-        private SvgAttributeCollection.InheritedAttribute<string> _clip;
-        private SvgAttributeCollection.InheritedAttribute<Uri> _clipPath;
-        private SvgAttributeCollection.InheritedAttribute<Uri> _filter;
-        private SvgAttributeCollection.Attribute<SvgClipRule> _clipRule;
+        private SvgAttributeCollection.Attribute<string> _clip;
+        private SvgAttributeCollection.Attribute<Uri> _clipPath;
+        private SvgAttributeCollection.Attribute<Uri> _filter;
+        private SvgAttributeCollection.InheritedAttribute<SvgClipRule> _clipRule;
 
         /// <summary>
         /// Gets the associated <see cref="SvgClipPath"/> if one has been specified.
@@ -161,7 +161,7 @@ namespace Svg
         [SvgAttribute("clip")]
         public virtual string Clip
         {
-            get { return  (_clip ??= this.Attributes.GetInheritedAttribute<string>("clip")).GetValue(); }
+            get { return  (_clip ??= this.Attributes.GetAttribute<string>("clip")).GetValue(); }
             set { this.Attributes["clip"] = value; }
         }
 
@@ -171,7 +171,7 @@ namespace Svg
         [SvgAttribute("clip-path")]
         public virtual Uri ClipPath
         {
-            get { return (_clipPath ??= this.Attributes.GetInheritedAttribute<Uri>("clip-path")).GetValue(); }
+            get { return (_clipPath ??= this.Attributes.GetAttribute<Uri>("clip-path")).GetValue(); }
             set { this.Attributes["clip-path"] = value; }
         }
 
@@ -181,7 +181,7 @@ namespace Svg
         [SvgAttribute("clip-rule")]
         public SvgClipRule ClipRule
         {
-            get { return (_clipRule ??= this.Attributes.GetAttribute<SvgClipRule>("clip-rule", SvgClipRule.NonZero)).GetValue(); }
+            get { return (_clipRule ??= this.Attributes.GetInheritedAttribute<SvgClipRule>("clip-rule")).GetValue(); }
             set { this.Attributes["clip-rule"] = value; }
         }
 
@@ -191,7 +191,7 @@ namespace Svg
         [SvgAttribute("filter")]
         public virtual Uri Filter
         {
-            get { return (_filter ??= this.Attributes.GetInheritedAttribute<Uri>("filter")).GetValue(); }
+            get { return (_filter ??= this.Attributes.GetAttribute<Uri>("filter")).GetValue(); }
             set { this.Attributes["filter"] = value; }
         }
         
@@ -278,7 +278,9 @@ namespace Svg
                     }
                     else
                     {
+                        this.SetClip(renderer);
                         base.RenderChildren(renderer);
+                        this.ResetClip(renderer);
                     }
                     this.PopTransforms(renderer);
                 }

--- a/Svg/Converters/BaseConverter.cs
+++ b/Svg/Converters/BaseConverter.cs
@@ -235,6 +235,9 @@ namespace Svg.Converters
 
             public override object ConvertFromString(string value, Type targetType, SvgDocument document)
             {
+                if (value == "none")
+                    return SvgFontVariant.Normal;
+
                 if (value == "small-caps")
                     return SvgFontVariant.Smallcaps;
 

--- a/Svg/Svg.csproj
+++ b/Svg/Svg.csproj
@@ -3,10 +3,12 @@
     <PropertyGroup>
         <TargetFrameworks>netstandard2.0;net48;net9.0</TargetFrameworks>
         <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-        <Version>3.1.2-optiq06</Version>
+        <Version>3.1.2-optiq07</Version>
         <Authors>gentledpp,zepr</Authors>
         <Company>Opti-Q GmbH</Company>
         <PackageReleaseNotes>
+			#3.1.2-optiq07
+			Fixed clip path property being inherited
 			#3.1.2-optiq06
 			Fixed: Sketch, when setting text and cancel dialog, opens new dialog and asks for font size
 			#3.1.2-optiq05


### PR DESCRIPTION
- According to [w3.org](https://www.w3.org/TR/SVG11/propidx.html), the clip-path property is not inherited and clip-rule is
- The [SVG.NET library](https://github.com/svg-net/SVG/issues/541) also corrected that a few years ago
- What was happening is that the text element would inherit the clip-path from its parent, and if the text had a transform, the clip-path would effectively be transformed as well, causing the text to clip itself.
- For example, if there was a clip-path going from y=-51 with height=50, and the text had a transform="translate(0, 20)":
   - The text would be rendered beginning from y=20 upwards,
   - The clip path would be transformed to y=-31 with height=50 hiding everything outside y=-31 to y=19, so you could see the whole text except for the small part at the bottom
   - The expected behavior for these values would be that the text is not visible at all because the clip-path should have hidden everything outside y=-51 to y=-1
- I also needed to call `SetClip` before and `ResetClip` after calling `RenderChildren` so that the group element would actually apply the clip-path. This wasn't the case before
- Also wrote some unit tests

## Before
https://github.com/user-attachments/assets/a6cbd804-003d-4ab4-8194-6cd01cc130ce

## After
https://github.com/user-attachments/assets/25ddf975-9e58-489a-bb8c-86e1508264f2