### PR TITLE
TileGenerator stores scale factor of tiles (in relation to original s…

### DIFF
--- a/Svg.Tests.Win/DeepZoom/TileGeneratorTests.cs
+++ b/Svg.Tests.Win/DeepZoom/TileGeneratorTests.cs
@@ -412,8 +412,41 @@ namespace Svg.Tests.Win
             var dims = System.Text.Json.JsonDocument.Parse(dimsJson).RootElement;
             Assert.AreEqual(pyramidW, dims.GetProperty("width").GetInt32(), "dimensions.json width mismatch.");
             Assert.AreEqual(pyramidH, dims.GetProperty("height").GetInt32(), "dimensions.json height mismatch.");
+            Assert.IsTrue(dims.TryGetProperty("scaleX", out _), "dimensions.json missing scaleX.");
+            Assert.IsTrue(dims.TryGetProperty("scaleY", out _), "dimensions.json missing scaleY.");
 #endif
         }
+
+#if !NETFRAMEWORK
+        [Test]
+        public async Task GenerateTilesFromSvgAsync_WritesScaleFactorsToDimensionsJson()
+        {
+            // Arrange — render the SVG into a pyramid 10× wider than the document so scaleX ≈ 10.
+            // Consumers (RenderOnPlanOptionsProvider) use these to re-map plan-item coordinates
+            // from the original SVG coordinate system into pyramid space and back.
+            var file = Path.Combine(TestContext.CurrentContext.WorkDirectory, "Assets\\plan_iss.svg");
+            var doc = SvgDocument.Open(file);
+            var docSize = doc.GetDimensions();
+            int targetWidth = (int)Math.Ceiling(docSize.Width * 10);
+            int pyramidH = (int)Math.Ceiling(targetWidth * docSize.Height / docSize.Width);
+            float expectedScaleX = targetWidth / docSize.Width;
+            float expectedScaleY = pyramidH / docSize.Height;
+
+            var tiles = new ConcurrentDictionary<string, MemoryStream>();
+
+            // Act
+            await new TileGenerator().GenerateTilesAsync(doc, targetWidth, CreateMemoryStreamProvider(tiles));
+
+            // Assert
+            Assert.IsTrue(tiles.ContainsKey("/dimensions.json"), "dimensions.json missing.");
+            var dimsJson = System.Text.Encoding.UTF8.GetString(tiles["/dimensions.json"].ToArray());
+            var dims = System.Text.Json.JsonDocument.Parse(dimsJson).RootElement;
+            Assert.AreEqual(expectedScaleX, (float)dims.GetProperty("scaleX").GetDouble(), 0.0001f,
+                "dimensions.json scaleX mismatch.");
+            Assert.AreEqual(expectedScaleY, (float)dims.GetProperty("scaleY").GetDouble(), 0.0001f,
+                "dimensions.json scaleY mismatch.");
+        }
+#endif
 
         [Test]
         public async Task GenerateTilesFromSvgAsync_TilesMatchCurrentPipeline_WithinTolerance()

--- a/Svg/DeepZoom/TileGenerator.cs
+++ b/Svg/DeepZoom/TileGenerator.cs
@@ -3,6 +3,7 @@ using Svg.Interfaces;
 using Svg.Platform;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -102,7 +103,7 @@ namespace Svg.DeepZoom
                 kvp.Value.Dispose();
             }
             pending.Clear();
-            await WriteMetadataAsync(originalWidth, originalHeight, tileOutputStreamProvider);
+            await WriteMetadataAsync(originalWidth, originalHeight, 1.0, 1.0, tileOutputStreamProvider);
         }
 
         private async Task GenerateZ0TilesSubsetAsync(
@@ -431,7 +432,7 @@ namespace Svg.DeepZoom
                 kvp.Value.Dispose();
             }
             pending.Clear();
-            await WriteMetadataAsync(pyramidW, pyramidH, tileOutputStreamProvider);
+            await WriteMetadataAsync(pyramidW, pyramidH, scaleX, scaleY, tileOutputStreamProvider);
         }
 
         private async Task WriteTileAndStorePendingAsync(
@@ -566,10 +567,13 @@ namespace Svg.DeepZoom
         }
 
         private static async Task WriteMetadataAsync(
-            int width, int height,
+            int width, int height, double scaleX, double scaleY,
             Func<string, string, Task<Stream>> streamProvider)
         {
-            var json = System.Text.Encoding.UTF8.GetBytes($"{{\"width\":{width},\"height\":{height}}}");
+            var sx = scaleX.ToString("R", CultureInfo.InvariantCulture);
+            var sy = scaleY.ToString("R", CultureInfo.InvariantCulture);
+            var json = System.Text.Encoding.UTF8.GetBytes(
+                $"{{\"width\":{width},\"height\":{height},\"scaleX\":{sx},\"scaleY\":{sy}}}");
             using var outStream = await streamProvider("", "dimensions.json");
             await outStream.WriteAsync(json, 0, json.Length);
         }

--- a/Svg/Svg.csproj
+++ b/Svg/Svg.csproj
@@ -3,10 +3,12 @@
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;net48;net10.0</TargetFrameworks>
 		<RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-		<Version>3.2.0-optiq01</Version>
+		<Version>3.2.0-optiq02</Version>
 		<Authors>gentledpp,zepr</Authors>
 		<Company>Opti-Q GmbH</Company>
 		<PackageReleaseNotes>
+			#3.2.0-optiq02
+			TileGenerator stores scale factor in dimensions.json (relative to svg dimensions)
 			#3.2.0-optiq01
 			Moved to avalonia 12
 			#3.1.4-optiq01


### PR DESCRIPTION
## Summary
- `TileGenerator.WriteMetadataAsync` now also writes `scaleX` and `scaleY` (in addition to `width`/`height`) into `dimensions.json`.
- For the SVG overload, the factor is `pyramidW / docSize.Width` (and Y analogous) — i.e. how much larger the rendered tile pyramid is than the original SVG document.
- For the raster overload (JPG/PNG source), `scaleX = scaleY = 1` is written, since the plan coordinate system equals the source pixel grid.
- Values are serialised with `"R"` round-trip formatting against `CultureInfo.InvariantCulture` so locales with comma decimal separators don't corrupt the JSON.

## Why
Consumers of the tile archive (in `iCl.Filler.Avalonia`) need this factor to re-map `PlanItem` coordinates between the original SVG coordinate system (in which they are persisted in production) and the higher-resolution tile pyramid. Without these fields the consumer cannot align pins/polygons on tile-rendered plans.

## Test plan
- [x] New test `GenerateTilesFromSvgAsync_WritesScaleFactorsToDimensionsJson` verifies that with `targetWidth = 10 × docSize.Width`, `scaleX ≈ 10` and `scaleY ≈ pyramidH/docSize.Height` are written and round-trip through `JsonDocument`.
- [x] Extended `GenerateTilesFromSvgAsync_ProducesExpectedZoomLevels` to also assert `scaleX/scaleY` are present.
- [x] Red/green: removed the new fields from `WriteMetadataAsync`, confirmed test fails; restored, confirmed it passes.

## Compatibility
Older tile archives without `scaleX/scaleY` will fail the strict parse on the consumer side and fall back to SVG/image rendering as before — no regression. The consuming feature is still in development, so backward compatibility of existing pyramids was not a requirement.